### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "repository": "https://github.com/fabiosantoscode/terser.git",
   "main": "dist/bundle.js",
+  "types": "tools/node.d.ts",
   "bin": {
     "terser": "bin/uglifyjs"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": "https://github.com/fabiosantoscode/terser.git",
   "main": "dist/bundle.js",
-  "types": "tools/node.d.ts",
+  "types": "tools/terser.d.ts",
   "bin": {
     "terser": "bin/uglifyjs"
   },

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -152,19 +152,30 @@ export interface SourceMapOptions {
 
 declare function parse(text: string, options?: any): string;
 
-type NodeE = any;
+declare class NodeElement {
+    constructor(props: any);
+    BASE?: NodeElement;
+    PROPS: string[];
+    SELF_PROPS: string[];
+    SUBCLASSES: NodeElement[];
+    TYPE: string;
+    documentation: string;
+    propdoc?: Record<string, string>;
+    warn?: (text: string, props: any) => void;
+    from_mozilla_ast?: (node: NodeElement) => any;
+}
 
 export class TreeWalker {
     constructor(callback: Function);
     directives: object;
-    find_parent(type: any): NodeE | undefined;
-    has_directive(type: any): void;
-    loopcontrol_target(node: NodeE): NodeE | undefined;
-    parent(n: number): NodeE | undefined;
+    find_parent(type: NodeElement): NodeElement | undefined;
+    has_directive(type: string): boolean;
+    loopcontrol_target(node: NodeElement): NodeElement | undefined;
+    parent(n: number): NodeElement | undefined;
     pop(): void;
-    push(node: NodeE): void;
-    self(): NodeE | undefined;
-    stack: NodeE[];
+    push(node: NodeElement): void;
+    self(): NodeElement | undefined;
+    stack: NodeElement[];
     visit: Function;
 }
 

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -135,10 +135,15 @@ export interface MinifyOptions {
     warnings?: boolean | 'verbose';
 }
 
+interface AST {
+    [key: string]: AST;
+}
+
 export interface MinifyOutput {
-    code: string;
+    ast?: AST;
+    code?: string;
     error?: Error;
-    map: string;
+    map?: string;
     warnings?: string[];
 }
 

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -203,6 +203,7 @@ export class AST_Node {
     static expressions?: AST_Node[];
     static warn?: (text: string, props: any) => void;
     static from_mozilla_ast?: (node: AST_Node) => any;
+    print_to_string(options?: OutputOptions);
     TYPE: string;
     CTOR: typeof AST_Node;
 }

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -150,7 +150,7 @@ export interface SourceMapOptions {
     url?: string | 'inline';
 }
 
-declare function parse(text: string, options?: any): string;
+declare function parse(text: string, options?: ParseOptions): string;
 
 declare class NodeElement {
     constructor(props: any);

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -1,12 +1,32 @@
 import { RawSourceMap } from 'source-map';
 
-export type ECMA = 5 | 6 | 7 | 8;
+export type ECMA = 5 | 6 | 7 | 8 | 9;
 
 export interface ParseOptions {
     bare_returns?: boolean;
     ecma?: ECMA;
     html5_comments?: boolean;
     shebang?: boolean;
+}
+
+export interface Def {
+    assignments: number;
+    chained: boolean;
+    direct_access: boolean;
+    escaped: boolean;
+    fixed: boolean;
+    scope: {
+        pinned: () => boolean;
+    };
+    init: any;
+    orig: AST_Node[];
+    recursive_refs: number;
+    references: any[];
+    should_replace: boolean;
+    single_use: boolean;
+    name: string;
+    id: any;
+    safe_ids: any[];
 }
 
 export interface CompressOptions {
@@ -30,9 +50,9 @@ export interface CompressOptions {
     if_return?: boolean;
     inline?: boolean | InlineFunctions;
     join_vars?: boolean;
-    keep_classnames?: boolean;
+    keep_classnames?: boolean | RegExp;
     keep_fargs?: boolean;
-    keep_fnames?: boolean;
+    keep_fnames?: boolean | RegExp;
     keep_infinity?: boolean;
     loops?: boolean;
     negate_iife?: boolean;
@@ -42,11 +62,11 @@ export interface CompressOptions {
     pure_getters?: boolean | 'strict';
     reduce_funcs?: boolean;
     reduce_vars?: boolean;
-    sequences?: boolean;
+    sequences?: boolean | number;
     side_effects?: boolean;
     switches?: boolean;
     toplevel?: boolean;
-    top_retain?: boolean;
+    top_retain?: null | string | string[] | RegExp | ((def: Def) => boolean);
     typeofs?: boolean;
     unsafe?: boolean;
     unsafe_arrows?: boolean;
@@ -69,8 +89,8 @@ export enum InlineFunctions {
 }
 export interface MangleOptions {
     eval?: boolean;
-    keep_classnames?: boolean;
-    keep_fnames?: boolean;
+    keep_classnames?: boolean | RegExp;
+    keep_fnames?: boolean | RegExp;
     module?: boolean;
     properties?: boolean | ManglePropertiesOptions;
     reserved?: string[];
@@ -122,8 +142,8 @@ export interface MinifyOptions {
     compress?: boolean | CompressOptions;
     ecma?: ECMA;
     ie8?: boolean;
-    keep_classnames?: boolean;
-    keep_fnames?: boolean;
+    keep_classnames?: boolean | RegExp;
+    keep_fnames?: boolean | RegExp;
     mangle?: boolean | MangleOptions;
     module?: boolean;
     nameCache?: object;
@@ -151,21 +171,7 @@ export interface SourceMapOptions {
     url?: string | 'inline';
 }
 
-declare function parse(text: string, options?: ParseOptions): string;
-
-declare class AST_Node {
-    constructor(props: any);
-    BASE?: AST_Node;
-    PROPS: string[];
-    SELF_PROPS: string[];
-    SUBCLASSES: AST_Node[];
-    TYPE: string;
-    documentation: string;
-    propdoc?: Record<string, string>;
-    expressions?: AST_Node[];
-    warn?: (text: string, props: any) => void;
-    from_mozilla_ast?: (node: AST_Node) => any;
-}
+declare function parse(text: string, options?: ParseOptions): AST_Node;
 
 export class TreeWalker {
     constructor(callback: (node: AST_Node, descend: boolean) => any);
@@ -204,4 +210,915 @@ export class Dictionary {
     size(): number;
 }
 
-export function minify(files: string | string[] | { [file: string]: string }, options?: MinifyOptions): MinifyOutput;
+export function minify(files: string | string[] | { [file: string]: string } | AST_Node, options?: MinifyOptions): MinifyOutput;
+
+declare class AST_Node {
+    constructor(props?: object);
+    static BASE?: AST_Node;
+    static PROPS: string[];
+    static SELF_PROPS: string[];
+    static SUBCLASSES: AST_Node[];
+    static documentation: string;
+    static propdoc?: Record<string, string>;
+    static expressions?: AST_Node[];
+    static warn?: (text: string, props: any) => void;
+    static from_mozilla_ast?: (node: AST_Node) => any;
+    TYPE: string;
+    CTOR: typeof AST_Node;
+}
+
+declare class AST_Statement extends AST_Node {
+    _codegen: Function;
+    _eval: Function;
+    negate: Function;
+    aborts: Function;
+}
+
+declare class AST_Debugger extends AST_Statement {
+    _codegen: Function;
+    add_source_map: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Directive extends AST_Statement {
+    _codegen: Function;
+    add_source_map: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_SimpleStatement extends AST_Statement {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Block extends AST_Statement {
+    _walk: Function;
+    clone: Function;
+    transform: Function;
+    is_block_scope: Function;
+    reduce_vars: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_BlockStatement extends AST_Block {
+    _codegen: Function;
+    add_source_map: Function;
+    aborts: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Scope extends AST_Block {
+    get_defun_scope: Function;
+    clone: Function;
+    pinned: Function;
+    init_scope_vars: Function;
+    find_variable: Function;
+    def_function: Function;
+    def_variable: Function;
+    next_mangled: Function;
+    process_expression: Function;
+    drop_unused: Function;
+    hoist_declarations: Function;
+    var_names: Function;
+    make_var_name: Function;
+    hoist_properties: Function;
+}
+
+declare class AST_Toplevel extends AST_Scope {
+    wrap_commonjs: Function;
+    wrap_enclose: Function;
+    figure_out_scope: Function;
+    def_global: Function;
+    is_block_scope: Function;
+    next_mangled: Function;
+    _default_mangler_options: Function;
+    mangle_names: Function;
+    find_colliding_names: Function;
+    expand_names: Function;
+    compute_char_frequency: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    drop_console: Function;
+    reduce_vars: Function;
+    reset_opt_flags: Function;
+    resolve_defines: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Lambda extends AST_Scope {
+    args_as_names: Function;
+    _walk: Function;
+    transform: Function;
+    is_block_scope: Function;
+    init_scope_vars: Function;
+    _do_print: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    optimize: Function;
+    contains_this: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Accessor extends AST_Lambda {
+    reduce_vars: Function;
+    drop_side_effect_free: Function;
+}
+
+declare class AST_Function extends AST_Lambda {
+    next_mangled: Function;
+    needs_parens: Function;
+    reduce_vars: Function;
+    _dot_throw: Function;
+    _eval: Function;
+    negate: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Arrow extends AST_Lambda {
+    init_scope_vars: Function;
+    needs_parens: Function;
+    _do_print: Function;
+    reduce_vars: Function;
+    _dot_throw: Function;
+    negate: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Defun extends AST_Lambda {
+    reduce_vars: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Class extends AST_Scope {
+    _walk: Function;
+    transform: Function;
+    is_block_scope: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_DefClass extends AST_Class {
+    reduce_vars: Function;
+    has_side_effects: Function;
+}
+
+declare class AST_ClassExpression extends AST_Class {
+    needs_parens: Function;
+    reduce_vars: Function;
+    drop_side_effect_free: Function;
+}
+
+declare class AST_Switch extends AST_Block {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_SwitchBranch extends AST_Block {
+    is_block_scope: Function;
+    _do_print_body: Function;
+    add_source_map: Function;
+    aborts: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Default extends AST_SwitchBranch {
+    _codegen: Function;
+    reduce_vars: Function;
+}
+
+declare class AST_Case extends AST_SwitchBranch {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+}
+
+declare class AST_Try extends AST_Block {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    reduce_vars: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Catch extends AST_Block {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Finally extends AST_Block {
+    _codegen: Function;
+    add_source_map: Function;
+}
+
+declare class AST_EmptyStatement extends AST_Statement {
+    _codegen: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_StatementWithBody extends AST_Statement {
+    _do_print_body: Function;
+    add_source_map: Function;
+}
+
+declare class AST_LabeledStatement extends AST_StatementWithBody {
+    _walk: Function;
+    clone: Function;
+    transform: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    reduce_vars: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_IterationStatement extends AST_StatementWithBody {
+    clone: Function;
+    is_block_scope: Function;
+}
+
+declare class AST_DWLoop extends AST_IterationStatement {
+
+}
+
+declare class AST_Do extends AST_DWLoop {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_While extends AST_DWLoop {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_For extends AST_IterationStatement {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_ForIn extends AST_IterationStatement {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_ForOf extends AST_ForIn {
+    to_mozilla_ast: Function;
+}
+
+declare class AST_With extends AST_StatementWithBody {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_If extends AST_StatementWithBody {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    aborts: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Jump extends AST_Statement {
+    add_source_map: Function;
+    aborts: Function;
+}
+
+declare class AST_Exit extends AST_Jump {
+    _walk: Function;
+    transform: Function;
+    _do_print: Function;
+}
+
+declare class AST_Return extends AST_Exit {
+    _codegen: Function;
+    may_throw: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Throw extends AST_Exit {
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_LoopControl extends AST_Jump {
+    _walk: Function;
+    transform: Function;
+    _do_print: Function;
+}
+
+declare class AST_Break extends AST_LoopControl {
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Continue extends AST_LoopControl {
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Definitions extends AST_Statement {
+    _walk: Function;
+    transform: Function;
+    _do_print: Function;
+    add_source_map: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    remove_initializers: Function;
+    to_assignments: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Var extends AST_Definitions {
+    _codegen: Function;
+}
+
+declare class AST_Let extends AST_Definitions {
+    _codegen: Function;
+}
+
+declare class AST_Const extends AST_Definitions {
+    _codegen: Function;
+}
+
+declare class AST_Export extends AST_Statement {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Expansion extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    _dot_throw: Function;
+    drop_side_effect_free: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Destructuring extends AST_Node {
+    _walk: Function;
+    all_symbols: Function;
+    transform: Function;
+    _codegen: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_PrefixedTemplateString extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_TemplateString extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    is_string: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_TemplateSegment extends AST_Node {
+    has_side_effects: Function;
+    drop_side_effect_free: Function;
+}
+
+declare class AST_NameMapping extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+}
+
+declare class AST_Import extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    aborts: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_VarDef extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Call extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    _codegen: Function;
+    _eval: Function;
+    is_expr_pure: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_New extends AST_Call {
+    needs_parens: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    _eval: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Sequence extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    tail_node: Function;
+    needs_parens: Function;
+    _do_print: Function;
+    _codegen: Function;
+    _dot_throw: Function;
+    is_boolean: Function;
+    is_number: Function;
+    is_string: Function;
+    negate: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_PropAccess extends AST_Node {
+    needs_parens: Function;
+    _eval: Function;
+    flatten_object: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Dot extends AST_PropAccess {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    _dot_throw: Function;
+    _find_defs: Function;
+    is_call_pure: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+}
+
+declare class AST_Sub extends AST_PropAccess {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+}
+
+declare class AST_Unary extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    reduce_vars: Function;
+    is_number: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    drop_side_effect_free: Function;
+    lift_sequences: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_UnaryPrefix extends AST_Unary {
+    _codegen: Function;
+    _dot_throw: Function;
+    is_boolean: Function;
+    is_string: Function;
+    _eval: Function;
+    negate: Function;
+    optimize: Function;
+}
+
+declare class AST_UnaryPostfix extends AST_Unary {
+    _codegen: Function;
+    _dot_throw: Function;
+    optimize: Function;
+}
+
+declare class AST_Binary extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    _dot_throw: Function;
+    is_boolean: Function;
+    is_number: Function;
+    is_string: Function;
+    _eval: Function;
+    negate: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    drop_side_effect_free: Function;
+    lift_sequences: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Assign extends AST_Binary {
+    needs_parens: Function;
+    reduce_vars: Function;
+    _dot_throw: Function;
+    is_boolean: Function;
+    is_number: Function;
+    is_string: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_DefaultAssign extends AST_Binary {
+    optimize: Function;
+}
+
+declare class AST_Conditional extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    _codegen: Function;
+    reduce_vars: Function;
+    _dot_throw: Function;
+    is_boolean: Function;
+    is_number: Function;
+    is_string: Function;
+    _eval: Function;
+    negate: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Array extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    _dot_throw: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Object extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    _dot_throw: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_ObjectProperty extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    _print_getter_setter: Function;
+    add_source_map: Function;
+    _dot_throw: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_ObjectKeyVal extends AST_ObjectProperty {
+    _codegen: Function;
+    optimize: Function;
+}
+
+declare class AST_ObjectSetter extends AST_ObjectProperty {
+    _codegen: Function;
+    add_source_map: Function;
+}
+
+declare class AST_ObjectGetter extends AST_ObjectProperty {
+    _codegen: Function;
+    add_source_map: Function;
+    _dot_throw: Function;
+}
+
+declare class AST_ConciseMethod extends AST_ObjectProperty {
+    _codegen: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Symbol extends AST_Node {
+    mark_enclosed: Function;
+    reference: Function;
+    unmangleable: Function;
+    unreferenced: Function;
+    definition: Function;
+    global: Function;
+    _do_print: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    fixed_value: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_SymbolDeclaration extends AST_Symbol {
+    _find_defs: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+}
+
+declare class AST_SymbolVar extends AST_SymbolDeclaration {
+
+}
+
+declare class AST_SymbolFunarg extends AST_SymbolVar {
+
+}
+
+declare class AST_SymbolBlockDeclaration extends AST_SymbolDeclaration {
+
+}
+
+declare class AST_SymbolConst extends AST_SymbolBlockDeclaration {
+
+}
+
+declare class AST_SymbolLet extends AST_SymbolBlockDeclaration {
+
+}
+
+declare class AST_SymbolDefClass extends AST_SymbolBlockDeclaration {
+
+}
+
+declare class AST_SymbolCatch extends AST_SymbolBlockDeclaration {
+    reduce_vars: Function;
+}
+
+declare class AST_SymbolImport extends AST_SymbolBlockDeclaration {
+
+}
+
+declare class AST_SymbolDefun extends AST_SymbolDeclaration {
+
+}
+
+declare class AST_SymbolLambda extends AST_SymbolDeclaration {
+
+}
+
+declare class AST_SymbolClass extends AST_SymbolDeclaration {
+
+}
+
+declare class AST_SymbolMethod extends AST_Symbol {
+
+}
+
+declare class AST_SymbolImportForeign extends AST_Symbol {
+
+}
+
+declare class AST_Label extends AST_Symbol {
+    initialize: Function;
+    unmangleable: Function;
+}
+
+declare class AST_SymbolRef extends AST_Symbol {
+    reduce_vars: Function;
+    is_immutable: Function;
+    is_declared: Function;
+    _dot_throw: Function;
+    _find_defs: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    optimize: Function;
+}
+
+declare class AST_SymbolExport extends AST_SymbolRef {
+    optimize: Function;
+}
+
+declare class AST_SymbolExportForeign extends AST_Symbol {
+
+}
+
+declare class AST_LabelRef extends AST_Symbol {
+
+}
+
+declare class AST_This extends AST_Symbol {
+    _codegen: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    drop_side_effect_free: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Super extends AST_This {
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_NewTarget extends AST_Node {
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Constant extends AST_Node {
+    getValue: Function;
+    _codegen: Function;
+    add_source_map: Function;
+    _dot_throw: Function;
+    _eval: Function;
+    has_side_effects: Function;
+    may_throw: Function;
+    is_constant_expression: Function;
+    drop_side_effect_free: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_String extends AST_Constant {
+    _codegen: Function;
+    is_string: Function;
+}
+
+declare class AST_Number extends AST_Constant {
+    needs_parens: Function;
+    _codegen: Function;
+    is_number: Function;
+}
+
+declare class AST_RegExp extends AST_Constant {
+    _codegen: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Atom extends AST_Constant {
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Null extends AST_Atom {
+    value: object;
+    _dot_throw: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_NaN extends AST_Atom {
+    value: number;
+    optimize: Function;
+}
+
+declare class AST_Undefined extends AST_Atom {
+    value: any;
+    _dot_throw: Function;
+    optimize: Function;
+}
+
+declare class AST_Hole extends AST_Atom {
+    value: any;
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Infinity extends AST_Atom {
+    value: number;
+    optimize: Function;
+}
+
+declare class AST_Boolean extends AST_Atom {
+    optimize: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_False extends AST_Boolean {
+    value: boolean;
+    is_boolean: Function;
+}
+
+declare class AST_True extends AST_Boolean {
+    value: boolean;
+    is_boolean: Function;
+}
+
+declare class AST_Await extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    _codegen: Function;
+    to_mozilla_ast: Function;
+}
+
+declare class AST_Yield extends AST_Node {
+    _walk: Function;
+    transform: Function;
+    needs_parens: Function;
+    _codegen: Function;
+    optimize: Function;
+    to_mozilla_ast: Function;
+}

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -9,26 +9,6 @@ export interface ParseOptions {
     shebang?: boolean;
 }
 
-export interface Def {
-    assignments: number;
-    chained: boolean;
-    direct_access: boolean;
-    escaped: boolean;
-    fixed: boolean;
-    scope: {
-        pinned: () => boolean;
-    };
-    init: any;
-    orig: AST_Node[];
-    recursive_refs: number;
-    references: any[];
-    should_replace: boolean;
-    single_use: boolean;
-    name: string;
-    id: any;
-    safe_ids: any[];
-}
-
 export interface CompressOptions {
     arguments?: boolean;
     arrows?: boolean;
@@ -66,7 +46,7 @@ export interface CompressOptions {
     side_effects?: boolean;
     switches?: boolean;
     toplevel?: boolean;
-    top_retain?: null | string | string[] | RegExp | ((def: Def) => boolean);
+    top_retain?: null | string | string[] | RegExp;
     typeofs?: boolean;
     unsafe?: boolean;
     unsafe_arrows?: boolean;
@@ -227,898 +207,577 @@ export class AST_Node {
     CTOR: typeof AST_Node;
 }
 
-export class AST_Statement extends AST_Node {
-    _codegen: Function;
-    _eval: Function;
-    negate: Function;
-    aborts: Function;
-}
-
-export class AST_Debugger extends AST_Statement {
-    _codegen: Function;
-    add_source_map: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Directive extends AST_Statement {
-    _codegen: Function;
-    add_source_map: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_SimpleStatement extends AST_Statement {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Block extends AST_Statement {
-    _walk: Function;
-    clone: Function;
-    transform: Function;
-    is_block_scope: Function;
-    reduce_vars: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_BlockStatement extends AST_Block {
-    _codegen: Function;
-    add_source_map: Function;
-    aborts: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Scope extends AST_Block {
-    get_defun_scope: Function;
-    clone: Function;
-    pinned: Function;
-    init_scope_vars: Function;
-    find_variable: Function;
-    def_function: Function;
-    def_variable: Function;
-    next_mangled: Function;
-    process_expression: Function;
-    drop_unused: Function;
-    hoist_declarations: Function;
-    var_names: Function;
-    make_var_name: Function;
-    hoist_properties: Function;
-}
-
-export class AST_Toplevel extends AST_Scope {
-    wrap_commonjs: Function;
-    wrap_enclose: Function;
-    figure_out_scope: Function;
-    def_global: Function;
-    is_block_scope: Function;
-    next_mangled: Function;
-    _default_mangler_options: Function;
-    mangle_names: Function;
-    find_colliding_names: Function;
-    expand_names: Function;
-    compute_char_frequency: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    drop_console: Function;
-    reduce_vars: Function;
-    reset_opt_flags: Function;
-    resolve_defines: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Lambda extends AST_Scope {
-    args_as_names: Function;
-    _walk: Function;
-    transform: Function;
-    is_block_scope: Function;
-    init_scope_vars: Function;
-    _do_print: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    optimize: Function;
-    contains_this: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Accessor extends AST_Lambda {
-    reduce_vars: Function;
-    drop_side_effect_free: Function;
-}
-
-export class AST_Function extends AST_Lambda {
-    next_mangled: Function;
-    needs_parens: Function;
-    reduce_vars: Function;
-    _dot_throw: Function;
-    _eval: Function;
-    negate: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Arrow extends AST_Lambda {
-    init_scope_vars: Function;
-    needs_parens: Function;
-    _do_print: Function;
-    reduce_vars: Function;
-    _dot_throw: Function;
-    negate: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Defun extends AST_Lambda {
-    reduce_vars: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Class extends AST_Scope {
-    _walk: Function;
-    transform: Function;
-    is_block_scope: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_DefClass extends AST_Class {
-    reduce_vars: Function;
-    has_side_effects: Function;
+declare class SymbolDef {
+    constructor(scope?: AST_Scope, orig?: object, init?: object);
+    name: string;
+    orig: AST_SymbolRef[];
+    init: AST_SymbolRef;
+    eliminated: number;
+    scope: AST_Scope;
+    references: AST_SymbolRef[];
+    replaced: number;
+    global: boolean;
+    export: boolean;
+    mangled_name: null | string;
+    undeclared: boolean;
+    id: number;
 }
 
-export class AST_ClassExpression extends AST_Class {
-    needs_parens: Function;
-    reduce_vars: Function;
-    drop_side_effect_free: Function;
+type ArgType = AST_SymbolFunarg | AST_DefaultAssign | AST_Destructuring | AST_Expansion;
+
+declare class AST_Statement extends AST_Node {
+    constructor(props?: object);
+}
+
+declare class AST_Debugger extends AST_Statement {
+    constructor(props?: object);
+}
+
+declare class AST_Directive extends AST_Statement {
+    constructor(props?: object);
+    value: string;
+    quote: string;
+}
+
+declare class AST_SimpleStatement extends AST_Statement {
+    constructor(props?: object);
+    body: AST_Node[];
+}
+
+declare class AST_Block extends AST_Statement {
+    constructor(props?: object);
+    body: AST_Node[];
+    block_scope: AST_Scope | null;
+}
+
+declare class AST_BlockStatement extends AST_Block {
+    constructor(props?: object);
+}
+
+declare class AST_Scope extends AST_Block {
+    constructor(props?: object);
+    variables: any;
+    functions: any;
+    uses_with: boolean;
+    uses_eval: boolean;
+    parent_scope: AST_Scope | null;
+    enclosed: any;
+    cname: any;
+}
+
+declare class AST_Toplevel extends AST_Scope {
+    constructor(props?: object);
+    globals: any;
+}
+
+declare class AST_Lambda extends AST_Scope {
+    constructor(props?: object);
+    name: AST_SymbolDeclaration | null;
+    argnames: ArgType[];
+    uses_arguments: boolean;
+    is_generator: boolean;
+    async: boolean;
+}
+
+declare class AST_Accessor extends AST_Lambda {
+    constructor(props?: object);
+}
+
+declare class AST_Function extends AST_Lambda {
+    constructor(props?: object);
+    inlined: boolean;
+}
+
+declare class AST_Arrow extends AST_Lambda {
+    constructor(props?: object);
+    inlined: boolean;
 }
-
-export class AST_Switch extends AST_Block {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+
+declare class AST_Defun extends AST_Lambda {
+    constructor(props?: object);
+    inlined: boolean;
+}
+
+declare class AST_Class extends AST_Scope {
+    constructor(props?: object);
+    name: AST_SymbolClass | AST_SymbolDefClass | null;
+    extends: AST_Node | null;
+    properties: AST_ObjectProperty[];
+    inlined: boolean;
+}
+
+declare class AST_DefClass extends AST_Class {
+    constructor(props?: object);
 }
 
-export class AST_SwitchBranch extends AST_Block {
-    is_block_scope: Function;
-    _do_print_body: Function;
-    add_source_map: Function;
-    aborts: Function;
-    to_mozilla_ast: Function;
-}
+declare class AST_ClassExpression extends AST_Class {
+    constructor(props?: object);
+}
 
-export class AST_Default extends AST_SwitchBranch {
-    _codegen: Function;
-    reduce_vars: Function;
+declare class AST_Switch extends AST_Block {
+    constructor(props?: object);
+    expression: AST_Node;
 }
-
-export class AST_Case extends AST_SwitchBranch {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    has_side_effects: Function;
-    may_throw: Function;
+
+declare class AST_SwitchBranch extends AST_Block {
+    constructor(props?: object);
 }
 
-export class AST_Try extends AST_Block {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    reduce_vars: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Default extends AST_SwitchBranch {
+    constructor(props?: object);
 }
 
-export class AST_Catch extends AST_Block {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    to_mozilla_ast: Function;
+declare class AST_Case extends AST_SwitchBranch {
+    constructor(props?: object);
+    expression: AST_Node;
 }
 
-export class AST_Finally extends AST_Block {
-    _codegen: Function;
-    add_source_map: Function;
+declare class AST_Try extends AST_Block {
+    constructor(props?: object);
+    bcatch: AST_Catch;
+    bfinally: null | AST_Finally;
 }
 
-export class AST_EmptyStatement extends AST_Statement {
-    _codegen: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    to_mozilla_ast: Function;
+declare class AST_Catch extends AST_Block {
+    constructor(props?: object);
+    argname: ArgType;
 }
 
-export class AST_StatementWithBody extends AST_Statement {
-    _do_print_body: Function;
-    add_source_map: Function;
+declare class AST_Finally extends AST_Block {
+    constructor(props?: object);
 }
 
-export class AST_LabeledStatement extends AST_StatementWithBody {
-    _walk: Function;
-    clone: Function;
-    transform: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    reduce_vars: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_EmptyStatement extends AST_Statement {
+    constructor(props?: object);
 }
 
-export class AST_IterationStatement extends AST_StatementWithBody {
-    clone: Function;
-    is_block_scope: Function;
+declare class AST_StatementWithBody extends AST_Statement {
+    constructor(props?: object);
+    body: AST_Node[];
 }
 
-export class AST_DWLoop extends AST_IterationStatement {
+declare class AST_LabeledStatement extends AST_StatementWithBody {
+    constructor(props?: object);
+    label: AST_Label;
+}
 
+declare class AST_IterationStatement extends AST_StatementWithBody {
+    constructor(props?: object);
+    block_scope: AST_Scope | null;
 }
 
-export class AST_Do extends AST_DWLoop {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_DWLoop extends AST_IterationStatement {
+    constructor(props?: object);
+    condition: AST_Node;
 }
 
-export class AST_While extends AST_DWLoop {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Do extends AST_DWLoop {
+    constructor(props?: object);
 }
 
-export class AST_For extends AST_IterationStatement {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_While extends AST_DWLoop {
+    constructor(props?: object);
 }
 
-export class AST_ForIn extends AST_IterationStatement {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    to_mozilla_ast: Function;
+declare class AST_For extends AST_IterationStatement {
+    constructor(props?: object);
+    init: AST_Node | null;
+    condition: AST_Node | null;
+    step: AST_Node | null;
 }
 
-export class AST_ForOf extends AST_ForIn {
-    to_mozilla_ast: Function;
+declare class AST_ForIn extends AST_IterationStatement {
+    constructor(props?: object);
+    init: AST_Node | null;
+    object: AST_Node;
 }
 
-export class AST_With extends AST_StatementWithBody {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_ForOf extends AST_ForIn {
+    constructor(props?: object);
+    await: boolean;
 }
 
-export class AST_If extends AST_StatementWithBody {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    aborts: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_With extends AST_StatementWithBody {
+    constructor(props?: object);
+    expression: AST_Node;
 }
 
-export class AST_Jump extends AST_Statement {
-    add_source_map: Function;
-    aborts: Function;
+declare class AST_If extends AST_StatementWithBody {
+    constructor(props?: object);
+    condition: AST_Node;
+    alternative: AST_Node | null;
 }
 
-export class AST_Exit extends AST_Jump {
-    _walk: Function;
-    transform: Function;
-    _do_print: Function;
+declare class AST_Jump extends AST_Statement {
+    constructor(props?: object);
 }
 
-export class AST_Return extends AST_Exit {
-    _codegen: Function;
-    may_throw: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Exit extends AST_Jump {
+    constructor(props?: object);
+    value: AST_Node | null;
 }
 
-export class AST_Throw extends AST_Exit {
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_Return extends AST_Exit {
+    constructor(props?: object);
 }
 
-export class AST_LoopControl extends AST_Jump {
-    _walk: Function;
-    transform: Function;
-    _do_print: Function;
+declare class AST_Throw extends AST_Exit {
+    constructor(props?: object);
 }
 
-export class AST_Break extends AST_LoopControl {
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_LoopControl extends AST_Jump {
+    constructor(props?: object);
+    label: null | AST_LabelRef;
 }
 
-export class AST_Continue extends AST_LoopControl {
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_Break extends AST_LoopControl {
+    constructor(props?: object);
 }
 
-export class AST_Definitions extends AST_Statement {
-    _walk: Function;
-    transform: Function;
-    _do_print: Function;
-    add_source_map: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    remove_initializers: Function;
-    to_assignments: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Continue extends AST_LoopControl {
+    constructor(props?: object);
 }
 
-export class AST_Var extends AST_Definitions {
-    _codegen: Function;
+declare class AST_Definitions extends AST_Statement {
+    constructor(props?: object);
+    definitions: AST_VarDef[];
 }
 
-export class AST_Let extends AST_Definitions {
-    _codegen: Function;
+declare class AST_Var extends AST_Definitions {
+    constructor(props?: object);
 }
 
-export class AST_Const extends AST_Definitions {
-    _codegen: Function;
+declare class AST_Let extends AST_Definitions {
+    constructor(props?: object);
 }
 
-export class AST_Export extends AST_Statement {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_Const extends AST_Definitions {
+    constructor(props?: object);
 }
 
-export class AST_Expansion extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    _dot_throw: Function;
-    drop_side_effect_free: Function;
-    to_mozilla_ast: Function;
+declare class AST_Export extends AST_Statement {
+    constructor(props?: object);
+    exported_definition: AST_Definitions | AST_Lambda | AST_DefClass | null;
+    exported_value: AST_Node | null;
+    is_default: boolean;
+    exported_names: AST_NameMapping[];
+    module_name: AST_String;
 }
 
-export class AST_Destructuring extends AST_Node {
-    _walk: Function;
-    all_symbols: Function;
-    transform: Function;
-    _codegen: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Expansion extends AST_Node {
+    constructor(props?: object);
+    expression: AST_Node;
 }
 
-export class AST_PrefixedTemplateString extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Destructuring extends AST_Node {
+    constructor(props?: object);
+    names: AST_Node[];
+    is_array: boolean;
 }
 
-export class AST_TemplateString extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    is_string: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_TemplateSegment extends AST_Node {
-    has_side_effects: Function;
-    drop_side_effect_free: Function;
+declare class AST_PrefixedTemplateString extends AST_Node {
+    constructor(props?: object);
+    template_string: AST_TemplateString;
+    prefix: AST_Node;
 }
-
-export class AST_NameMapping extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-}
-
-export class AST_Import extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    aborts: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_VarDef extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Call extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    _codegen: Function;
-    _eval: Function;
-    is_expr_pure: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_New extends AST_Call {
-    needs_parens: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    _eval: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Sequence extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    tail_node: Function;
-    needs_parens: Function;
-    _do_print: Function;
-    _codegen: Function;
-    _dot_throw: Function;
-    is_boolean: Function;
-    is_number: Function;
-    is_string: Function;
-    negate: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_PropAccess extends AST_Node {
-    needs_parens: Function;
-    _eval: Function;
-    flatten_object: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Dot extends AST_PropAccess {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    _dot_throw: Function;
-    _find_defs: Function;
-    is_call_pure: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-}
-
-export class AST_Sub extends AST_PropAccess {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-}
-
-export class AST_Unary extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    reduce_vars: Function;
-    is_number: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    drop_side_effect_free: Function;
-    lift_sequences: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_UnaryPrefix extends AST_Unary {
-    _codegen: Function;
-    _dot_throw: Function;
-    is_boolean: Function;
-    is_string: Function;
-    _eval: Function;
-    negate: Function;
-    optimize: Function;
-}
-
-export class AST_UnaryPostfix extends AST_Unary {
-    _codegen: Function;
-    _dot_throw: Function;
-    optimize: Function;
-}
-
-export class AST_Binary extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    _dot_throw: Function;
-    is_boolean: Function;
-    is_number: Function;
-    is_string: Function;
-    _eval: Function;
-    negate: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    drop_side_effect_free: Function;
-    lift_sequences: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Assign extends AST_Binary {
-    needs_parens: Function;
-    reduce_vars: Function;
-    _dot_throw: Function;
-    is_boolean: Function;
-    is_number: Function;
-    is_string: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_DefaultAssign extends AST_Binary {
-    optimize: Function;
-}
-
-export class AST_Conditional extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    _codegen: Function;
-    reduce_vars: Function;
-    _dot_throw: Function;
-    is_boolean: Function;
-    is_number: Function;
-    is_string: Function;
-    _eval: Function;
-    negate: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
-}
-
-export class AST_Array extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    _dot_throw: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+
+declare class AST_TemplateString extends AST_Node {
+    constructor(props?: object);
+    segments: AST_Node[];
 }
 
-export class AST_Object extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    _dot_throw: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_TemplateSegment extends AST_Node {
+    constructor(props?: object);
+    value: string;
+    raw: string;
 }
 
-export class AST_ObjectProperty extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    _print_getter_setter: Function;
-    add_source_map: Function;
-    _dot_throw: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_NameMapping extends AST_Node {
+    constructor(props?: object);
+    foreign_name: AST_Symbol;
+    name: AST_SymbolExport | AST_SymbolImport;
 }
 
-export class AST_ObjectKeyVal extends AST_ObjectProperty {
-    _codegen: Function;
-    optimize: Function;
+declare class AST_Import extends AST_Node {
+    constructor(props?: object);
+    imported_name: null | AST_SymbolImport;
+    imported_names: AST_NameMapping[];
+    module_name: AST_String;
 }
 
-export class AST_ObjectSetter extends AST_ObjectProperty {
-    _codegen: Function;
-    add_source_map: Function;
+declare class AST_VarDef extends AST_Node {
+    constructor(props?: object);
+    name: AST_Destructuring | AST_SymbolConst | AST_SymbolLet | AST_SymbolVar;
+    value: AST_Node | null;
 }
 
-export class AST_ObjectGetter extends AST_ObjectProperty {
-    _codegen: Function;
-    add_source_map: Function;
-    _dot_throw: Function;
+declare class AST_Call extends AST_Node {
+    constructor(props?: object);
+    expression: AST_Node;
+    args: AST_Node[];
 }
 
-export class AST_ConciseMethod extends AST_ObjectProperty {
-    _codegen: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_New extends AST_Call {
+    constructor(props?: object);
 }
 
-export class AST_Symbol extends AST_Node {
-    mark_enclosed: Function;
-    reference: Function;
-    unmangleable: Function;
-    unreferenced: Function;
-    definition: Function;
-    global: Function;
-    _do_print: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    fixed_value: Function;
-    to_mozilla_ast: Function;
+declare class AST_Sequence extends AST_Node {
+    constructor(props?: object);
+    expressions: AST_Node[];
 }
 
-export class AST_SymbolDeclaration extends AST_Symbol {
-    _find_defs: Function;
-    has_side_effects: Function;
-    may_throw: Function;
+declare class AST_PropAccess extends AST_Node {
+    constructor(props?: object);
+    expression: AST_Node;
+    property: AST_Node | string;
 }
 
-export class AST_SymbolVar extends AST_SymbolDeclaration {
+declare class AST_Dot extends AST_PropAccess {
+    constructor(props?: object);
+}
 
+declare class AST_Sub extends AST_PropAccess {
+    constructor(props?: object);
 }
 
-export class AST_SymbolFunarg extends AST_SymbolVar {
+declare class AST_Unary extends AST_Node {
+    constructor(props?: object);
+    operator: string;
+    expression: AST_Node;
+}
 
+declare class AST_UnaryPrefix extends AST_Unary {
+    constructor(props?: object);
 }
 
-export class AST_SymbolBlockDeclaration extends AST_SymbolDeclaration {
+declare class AST_UnaryPostfix extends AST_Unary {
+    constructor(props?: object);
+}
 
+declare class AST_Binary extends AST_Node {
+    constructor(props?: object);
+    operator: string;
+    left: AST_Node;
+    right: AST_Node;
 }
 
-export class AST_SymbolConst extends AST_SymbolBlockDeclaration {
+declare class AST_Assign extends AST_Binary {
+    constructor(props?: object);
+}
 
+declare class AST_DefaultAssign extends AST_Binary {
+    constructor(props?: object);
 }
 
-export class AST_SymbolLet extends AST_SymbolBlockDeclaration {
+declare class AST_Conditional extends AST_Node {
+    constructor(props?: object);
+    condition: AST_Node;
+    consequent: AST_Node;
+    alternative: AST_Node | null;
+}
 
+declare class AST_Array extends AST_Node {
+    constructor(props?: object);
+    elements: AST_Node[];
 }
 
-export class AST_SymbolDefClass extends AST_SymbolBlockDeclaration {
+declare class AST_Object extends AST_Node {
+    constructor(props?: object);
+    properties: AST_ObjectProperty[];
+}
 
+declare class AST_ObjectProperty extends AST_Node {
+    constructor(props?: object);
+    key: string | number | AST_Node;
+    value: AST_Node;
 }
 
-export class AST_SymbolCatch extends AST_SymbolBlockDeclaration {
-    reduce_vars: Function;
+declare class AST_ObjectKeyVal extends AST_ObjectProperty {
+    constructor(props?: object);
+    quote: string;
 }
 
-export class AST_SymbolImport extends AST_SymbolBlockDeclaration {
+declare class AST_ObjectSetter extends AST_ObjectProperty {
+    constructor(props?: object);
+    quote: string;
+    static: boolean;
+}
 
+declare class AST_ObjectGetter extends AST_ObjectProperty {
+    constructor(props?: object);
+    quote: string;
+    static: boolean;
 }
 
-export class AST_SymbolDefun extends AST_SymbolDeclaration {
+declare class AST_ConciseMethod extends AST_ObjectProperty {
+    constructor(props?: object);
+    quote: string;
+    static: boolean;
+    is_generator: boolean;
+    async: boolean;
+}
 
+declare class AST_Symbol extends AST_Node {
+    constructor(props?: object);
+    scope: AST_Scope;
+    name: string;
+    thedef: SymbolDef;
 }
 
-export class AST_SymbolLambda extends AST_SymbolDeclaration {
+declare class AST_SymbolDeclaration extends AST_Symbol {
+    constructor(props?: object);
+    init: AST_Node | null;
+}
 
+declare class AST_SymbolVar extends AST_SymbolDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_SymbolClass extends AST_SymbolDeclaration {
+declare class AST_SymbolFunarg extends AST_SymbolVar {
+    constructor(props?: object);
+}
 
+declare class AST_SymbolBlockDeclaration extends AST_SymbolDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_SymbolMethod extends AST_Symbol {
+declare class AST_SymbolConst extends AST_SymbolBlockDeclaration {
+    constructor(props?: object);
+}
 
+declare class AST_SymbolLet extends AST_SymbolBlockDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_SymbolImportForeign extends AST_Symbol {
+declare class AST_SymbolDefClass extends AST_SymbolBlockDeclaration {
+    constructor(props?: object);
+}
 
+declare class AST_SymbolCatch extends AST_SymbolBlockDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_Label extends AST_Symbol {
-    initialize: Function;
-    unmangleable: Function;
+declare class AST_SymbolImport extends AST_SymbolBlockDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_SymbolRef extends AST_Symbol {
-    reduce_vars: Function;
-    is_immutable: Function;
-    is_declared: Function;
-    _dot_throw: Function;
-    _find_defs: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    optimize: Function;
+declare class AST_SymbolDefun extends AST_SymbolDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_SymbolExport extends AST_SymbolRef {
-    optimize: Function;
+declare class AST_SymbolLambda extends AST_SymbolDeclaration {
+    constructor(props?: object);
 }
 
-export class AST_SymbolExportForeign extends AST_Symbol {
+declare class AST_SymbolClass extends AST_SymbolDeclaration {
+    constructor(props?: object);
+}
 
+declare class AST_SymbolMethod extends AST_Symbol {
+    constructor(props?: object);
 }
 
-export class AST_LabelRef extends AST_Symbol {
+declare class AST_SymbolImportForeign extends AST_Symbol {
+    constructor(props?: object);
+}
 
+declare class AST_Label extends AST_Symbol {
+    constructor(props?: object);
+    references: AST_LoopControl | null;
 }
 
-export class AST_This extends AST_Symbol {
-    _codegen: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    drop_side_effect_free: Function;
-    to_mozilla_ast: Function;
+declare class AST_SymbolRef extends AST_Symbol {
+    constructor(props?: object);
 }
 
-export class AST_Super extends AST_This {
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_SymbolExport extends AST_SymbolRef {
+    constructor(props?: object);
 }
 
-export class AST_NewTarget extends AST_Node {
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_SymbolExportForeign extends AST_Symbol {
+    constructor(props?: object);
 }
 
-export class AST_Constant extends AST_Node {
-    getValue: Function;
-    _codegen: Function;
-    add_source_map: Function;
-    _dot_throw: Function;
-    _eval: Function;
-    has_side_effects: Function;
-    may_throw: Function;
-    is_constant_expression: Function;
-    drop_side_effect_free: Function;
-    to_mozilla_ast: Function;
+declare class AST_LabelRef extends AST_Symbol {
+    constructor(props?: object);
 }
 
-export class AST_String extends AST_Constant {
-    _codegen: Function;
-    is_string: Function;
+declare class AST_This extends AST_Symbol {
+    constructor(props?: object);
 }
 
-export class AST_Number extends AST_Constant {
-    needs_parens: Function;
-    _codegen: Function;
-    is_number: Function;
+declare class AST_Super extends AST_This {
+    constructor(props?: object);
 }
 
-export class AST_RegExp extends AST_Constant {
-    _codegen: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_NewTarget extends AST_Node {
+    constructor(props?: object);
 }
 
-export class AST_Atom extends AST_Constant {
-    to_mozilla_ast: Function;
+declare class AST_Constant extends AST_Node {
+    constructor(props?: object);
 }
 
-export class AST_Null extends AST_Atom {
-    value: object;
-    _dot_throw: Function;
-    to_mozilla_ast: Function;
+declare class AST_String extends AST_Constant {
+    constructor(props?: object);
+    value: string;
+    quote: string;
 }
 
-export class AST_NaN extends AST_Atom {
+declare class AST_Number extends AST_Constant {
+    constructor(props?: object);
     value: number;
-    optimize: Function;
+    literal: string;
 }
 
-export class AST_Undefined extends AST_Atom {
-    value: any;
-    _dot_throw: Function;
-    optimize: Function;
+declare class AST_RegExp extends AST_Constant {
+    constructor(props?: object);
+    value: RegExp;
 }
 
-export class AST_Hole extends AST_Atom {
-    value: any;
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_Atom extends AST_Constant {
+    constructor(props?: object);
 }
 
-export class AST_Infinity extends AST_Atom {
-    value: number;
-    optimize: Function;
+declare class AST_Null extends AST_Atom {
+    constructor(props?: object);
 }
 
-export class AST_Boolean extends AST_Atom {
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_NaN extends AST_Atom {
+    constructor(props?: object);
 }
 
-export class AST_False extends AST_Boolean {
-    value: boolean;
-    is_boolean: Function;
+declare class AST_Undefined extends AST_Atom {
+    constructor(props?: object);
 }
 
-export class AST_True extends AST_Boolean {
-    value: boolean;
-    is_boolean: Function;
+declare class AST_Hole extends AST_Atom {
+    constructor(props?: object);
 }
 
-export class AST_Await extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    _codegen: Function;
-    to_mozilla_ast: Function;
+declare class AST_Infinity extends AST_Atom {
+    constructor(props?: object);
 }
 
-export class AST_Yield extends AST_Node {
-    _walk: Function;
-    transform: Function;
-    needs_parens: Function;
-    _codegen: Function;
-    optimize: Function;
-    to_mozilla_ast: Function;
+declare class AST_Boolean extends AST_Atom {
+    constructor(props?: object);
+}
+
+declare class AST_False extends AST_Boolean {
+    constructor(props?: object);
+}
+
+declare class AST_True extends AST_Boolean {
+    constructor(props?: object);
+}
+
+declare class AST_Await extends AST_Node {
+    constructor(props?: object);
+    expression: AST_Node;
+}
+
+declare class AST_Yield extends AST_Node {
+    constructor(props?: object);
+    expression: AST_Node;
+    is_star: boolean;
 }

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -135,12 +135,8 @@ export interface MinifyOptions {
     warnings?: boolean | 'verbose';
 }
 
-interface AST {
-    [key: string]: AST;
-}
-
 export interface MinifyOutput {
-    ast?: AST;
+    ast?: AST_Node;
     code?: string;
     error?: Error;
     map?: string;
@@ -157,38 +153,38 @@ export interface SourceMapOptions {
 
 declare function parse(text: string, options?: ParseOptions): string;
 
-declare class NodeElement {
+declare class AST_Node {
     constructor(props: any);
-    BASE?: NodeElement;
+    BASE?: AST_Node;
     PROPS: string[];
     SELF_PROPS: string[];
-    SUBCLASSES: NodeElement[];
+    SUBCLASSES: AST_Node[];
     TYPE: string;
     documentation: string;
     propdoc?: Record<string, string>;
-    expressions?: NodeElement[];
+    expressions?: AST_Node[];
     warn?: (text: string, props: any) => void;
-    from_mozilla_ast?: (node: NodeElement) => any;
+    from_mozilla_ast?: (node: AST_Node) => any;
 }
 
 export class TreeWalker {
-    constructor(callback: (node: NodeElement, descend: boolean) => any);
+    constructor(callback: (node: AST_Node, descend: boolean) => any);
     directives: object;
-    find_parent(type: NodeElement): NodeElement | undefined;
+    find_parent(type: AST_Node): AST_Node | undefined;
     has_directive(type: string): boolean;
-    loopcontrol_target(node: NodeElement): NodeElement | undefined;
-    parent(n: number): NodeElement | undefined;
+    loopcontrol_target(node: AST_Node): AST_Node | undefined;
+    parent(n: number): AST_Node | undefined;
     pop(): void;
-    push(node: NodeElement): void;
-    self(): NodeElement | undefined;
-    stack: NodeElement[];
-    visit: (node: NodeElement, descend: boolean) => any;
+    push(node: AST_Node): void;
+    self(): AST_Node | undefined;
+    stack: AST_Node[];
+    visit: (node: AST_Node, descend: boolean) => any;
 }
 
 export class TreeTransformer extends TreeWalker {
-    constructor(before: (node: NodeElement) => NodeElement, after?: (node: NodeElement) => NodeElement);
-    before: (node: NodeElement) => NodeElement;
-    after?: (node: NodeElement) => NodeElement;
+    constructor(before: (node: AST_Node) => AST_Node, after?: (node: AST_Node) => AST_Node);
+    before: (node: AST_Node) => AST_Node;
+    after?: (node: AST_Node) => AST_Node;
 }
 
 export function push_uniq<T>(array: T[], el: T): void;

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -1,0 +1,188 @@
+import { RawSourceMap } from 'source-map';
+
+export type ECMA = 5 | 6 | 7 | 8;
+
+export interface ParseOptions {
+    bare_returns?: boolean;
+    ecma?: ECMA;
+    html5_comments?: boolean;
+    shebang?: boolean;
+}
+
+export interface CompressOptions {
+    arguments?: boolean;
+    arrows?: boolean;
+    booleans?: boolean;
+    collapse_vars?: boolean;
+    comparisons?: boolean;
+    conditionals?: boolean;
+    dead_code?: boolean;
+    defaults?: boolean;
+    directives?: boolean;
+    drop_console?: boolean;
+    drop_debugger?: boolean;
+    evaluate?: boolean;
+    expression?: boolean;
+    global_defs?: object;
+    hoist_funs?: boolean;
+    hoist_props?: boolean;
+    hoist_vars?: boolean;
+    if_return?: boolean;
+    inline?: boolean | InlineFunctions;
+    join_vars?: boolean;
+    keep_classnames?: boolean;
+    keep_fargs?: boolean;
+    keep_fnames?: boolean;
+    keep_infinity?: boolean;
+    loops?: boolean;
+    negate_iife?: boolean;
+    passes?: number;
+    properties?: boolean;
+    pure_funcs?: string[];
+    pure_getters?: boolean | 'strict';
+    reduce_funcs?: boolean;
+    reduce_vars?: boolean;
+    sequences?: boolean;
+    side_effects?: boolean;
+    switches?: boolean;
+    toplevel?: boolean;
+    top_retain?: boolean;
+    typeofs?: boolean;
+    unsafe?: boolean;
+    unsafe_arrows?: boolean;
+    unsafe_comps?: boolean;
+    unsafe_Function?: boolean;
+    unsafe_math?: boolean;
+    unsafe_methods?: boolean;
+    unsafe_proto?: boolean;
+    unsafe_regexp?: boolean;
+    unsafe_undefined?: boolean;
+    unused?: boolean;
+    warnings?: boolean;
+}
+
+export enum InlineFunctions {
+    Disabled = 0,
+    SimpleFunctions = 1,
+    WithArguments = 2,
+    WithArgumentsAndVariables = 3
+}
+export interface MangleOptions {
+    eval?: boolean;
+    keep_classnames?: boolean;
+    keep_fnames?: boolean;
+    module?: boolean;
+    properties?: boolean | ManglePropertiesOptions;
+    reserved?: string[];
+    safari10?: boolean;
+    toplevel?: boolean;
+}
+
+export interface ManglePropertiesOptions {
+    builtins?: boolean;
+    debug?: boolean;
+    keep_quoted?: boolean;
+    regex?: RegExp;
+    reserved?: string[];
+}
+
+export interface OutputOptions {
+    ascii_only?: boolean;
+    beautify?: boolean;
+    braces?: boolean;
+    comments?: boolean | 'all' | 'some' | RegExp;
+    ecma?: ECMA;
+    indent_level?: number;
+    indent_start?: boolean;
+    inline_script?: boolean;
+    is8?: boolean;
+    keep_quoted_props?: boolean;
+    max_line_len?: boolean;
+    preamble?: string;
+    quote_keys?: boolean;
+    quote_style?: OutputQuoteStyle;
+    safari10?: boolean;
+    semicolons?: boolean;
+    shebang?: boolean;
+    shorthand?: boolean;
+    source_map?: SourceMapOptions;
+    webkit?: boolean;
+    width?: number;
+    wrap_iife?: boolean;
+}
+
+export enum OutputQuoteStyle {
+    PreferDouble = 0,
+    AlwaysSingle = 1,
+    AlwaysDouble = 2,
+    AlwaysOriginal = 3
+}
+
+export interface MinifyOptions {
+    compress?: boolean | CompressOptions;
+    ecma?: ECMA;
+    ie8?: boolean;
+    keep_classnames?: boolean;
+    keep_fnames?: boolean;
+    mangle?: boolean | MangleOptions;
+    module?: boolean;
+    nameCache?: object;
+    output?: OutputOptions;
+    parse?: ParseOptions;
+    safari10?: boolean;
+    sourceMap?: boolean | SourceMapOptions;
+    toplevel?: boolean;
+    warnings?: boolean | 'verbose';
+}
+
+export interface MinifyOutput {
+    code: string;
+    error?: Error;
+    map: string;
+    warnings?: string[];
+}
+
+export interface SourceMapOptions {
+    content?: RawSourceMap;
+    includeSources?: boolean;
+    filename?: string;
+    root?: string;
+    url?: string | 'inline';
+}
+
+declare function parse(text: string, options?: any): string;
+
+type NodeE = any;
+
+export class TreeWalker {
+    constructor(callback: Function);
+    directives: object;
+    find_parent(type: any): NodeE | undefined;
+    has_directive(type: any): void;
+    loopcontrol_target(node: NodeE): NodeE | undefined;
+    parent(n: number): NodeE | undefined;
+    pop(): void;
+    push(node: NodeE): void;
+    self(): NodeE | undefined;
+    stack: NodeE[];
+    visit: Function;
+}
+
+export function push_uniq<T>(array: T[], el: T): void;
+
+type DictEachCallback = (val: any, key: string) => any;
+
+export class Dictionary {
+    static fromObject(obj: object): Dictionary;
+    add(key: string, val: any): this;
+    clone(): Dictionary;
+    del(key: string): this;
+    each(fn: DictEachCallback): void;
+    get(key: string): any;
+    has(key: string): boolean;
+    map(fn: DictEachCallback): any[];
+    set(key: string, val: any): this;
+    size(): number;
+}
+
+export function minify(files: string | string[] | { [file: string]: string }, options?: MinifyOptions): MinifyOutput;

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -167,7 +167,7 @@ declare class NodeElement {
 }
 
 export class TreeWalker {
-    constructor(callback: (node: NodeElement, descend: boolean) => NodeElement);
+    constructor(callback: (node: NodeElement, descend: boolean) => any);
     directives: object;
     find_parent(type: NodeElement): NodeElement | undefined;
     has_directive(type: string): boolean;
@@ -177,7 +177,7 @@ export class TreeWalker {
     push(node: NodeElement): void;
     self(): NodeElement | undefined;
     stack: NodeElement[];
-    visit: (node: NodeElement, descend: boolean) => NodeElement;
+    visit: (node: NodeElement, descend: boolean) => any;
 }
 
 export class TreeTransformer extends TreeWalker {

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -212,7 +212,7 @@ export class Dictionary {
 
 export function minify(files: string | string[] | { [file: string]: string } | AST_Node, options?: MinifyOptions): MinifyOutput;
 
-declare class AST_Node {
+export class AST_Node {
     constructor(props?: object);
     static BASE?: AST_Node;
     static PROPS: string[];
@@ -227,28 +227,28 @@ declare class AST_Node {
     CTOR: typeof AST_Node;
 }
 
-declare class AST_Statement extends AST_Node {
+export class AST_Statement extends AST_Node {
     _codegen: Function;
     _eval: Function;
     negate: Function;
     aborts: Function;
 }
 
-declare class AST_Debugger extends AST_Statement {
+export class AST_Debugger extends AST_Statement {
     _codegen: Function;
     add_source_map: Function;
     optimize: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Directive extends AST_Statement {
+export class AST_Directive extends AST_Statement {
     _codegen: Function;
     add_source_map: Function;
     optimize: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_SimpleStatement extends AST_Statement {
+export class AST_SimpleStatement extends AST_Statement {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -258,7 +258,7 @@ declare class AST_SimpleStatement extends AST_Statement {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Block extends AST_Statement {
+export class AST_Block extends AST_Statement {
     _walk: Function;
     clone: Function;
     transform: Function;
@@ -270,7 +270,7 @@ declare class AST_Block extends AST_Statement {
     to_mozilla_ast: Function;
 }
 
-declare class AST_BlockStatement extends AST_Block {
+export class AST_BlockStatement extends AST_Block {
     _codegen: Function;
     add_source_map: Function;
     aborts: Function;
@@ -278,7 +278,7 @@ declare class AST_BlockStatement extends AST_Block {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Scope extends AST_Block {
+export class AST_Scope extends AST_Block {
     get_defun_scope: Function;
     clone: Function;
     pinned: Function;
@@ -295,7 +295,7 @@ declare class AST_Scope extends AST_Block {
     hoist_properties: Function;
 }
 
-declare class AST_Toplevel extends AST_Scope {
+export class AST_Toplevel extends AST_Scope {
     wrap_commonjs: Function;
     wrap_enclose: Function;
     figure_out_scope: Function;
@@ -316,7 +316,7 @@ declare class AST_Toplevel extends AST_Scope {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Lambda extends AST_Scope {
+export class AST_Lambda extends AST_Scope {
     args_as_names: Function;
     _walk: Function;
     transform: Function;
@@ -334,12 +334,12 @@ declare class AST_Lambda extends AST_Scope {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Accessor extends AST_Lambda {
+export class AST_Accessor extends AST_Lambda {
     reduce_vars: Function;
     drop_side_effect_free: Function;
 }
 
-declare class AST_Function extends AST_Lambda {
+export class AST_Function extends AST_Lambda {
     next_mangled: Function;
     needs_parens: Function;
     reduce_vars: Function;
@@ -351,7 +351,7 @@ declare class AST_Function extends AST_Lambda {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Arrow extends AST_Lambda {
+export class AST_Arrow extends AST_Lambda {
     init_scope_vars: Function;
     needs_parens: Function;
     _do_print: Function;
@@ -363,12 +363,12 @@ declare class AST_Arrow extends AST_Lambda {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Defun extends AST_Lambda {
+export class AST_Defun extends AST_Lambda {
     reduce_vars: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Class extends AST_Scope {
+export class AST_Class extends AST_Scope {
     _walk: Function;
     transform: Function;
     is_block_scope: Function;
@@ -382,18 +382,18 @@ declare class AST_Class extends AST_Scope {
     to_mozilla_ast: Function;
 }
 
-declare class AST_DefClass extends AST_Class {
+export class AST_DefClass extends AST_Class {
     reduce_vars: Function;
     has_side_effects: Function;
 }
 
-declare class AST_ClassExpression extends AST_Class {
+export class AST_ClassExpression extends AST_Class {
     needs_parens: Function;
     reduce_vars: Function;
     drop_side_effect_free: Function;
 }
 
-declare class AST_Switch extends AST_Block {
+export class AST_Switch extends AST_Block {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -404,7 +404,7 @@ declare class AST_Switch extends AST_Block {
     to_mozilla_ast: Function;
 }
 
-declare class AST_SwitchBranch extends AST_Block {
+export class AST_SwitchBranch extends AST_Block {
     is_block_scope: Function;
     _do_print_body: Function;
     add_source_map: Function;
@@ -412,12 +412,12 @@ declare class AST_SwitchBranch extends AST_Block {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Default extends AST_SwitchBranch {
+export class AST_Default extends AST_SwitchBranch {
     _codegen: Function;
     reduce_vars: Function;
 }
 
-declare class AST_Case extends AST_SwitchBranch {
+export class AST_Case extends AST_SwitchBranch {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -426,7 +426,7 @@ declare class AST_Case extends AST_SwitchBranch {
     may_throw: Function;
 }
 
-declare class AST_Try extends AST_Block {
+export class AST_Try extends AST_Block {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -438,7 +438,7 @@ declare class AST_Try extends AST_Block {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Catch extends AST_Block {
+export class AST_Catch extends AST_Block {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -446,24 +446,24 @@ declare class AST_Catch extends AST_Block {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Finally extends AST_Block {
+export class AST_Finally extends AST_Block {
     _codegen: Function;
     add_source_map: Function;
 }
 
-declare class AST_EmptyStatement extends AST_Statement {
+export class AST_EmptyStatement extends AST_Statement {
     _codegen: Function;
     has_side_effects: Function;
     may_throw: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_StatementWithBody extends AST_Statement {
+export class AST_StatementWithBody extends AST_Statement {
     _do_print_body: Function;
     add_source_map: Function;
 }
 
-declare class AST_LabeledStatement extends AST_StatementWithBody {
+export class AST_LabeledStatement extends AST_StatementWithBody {
     _walk: Function;
     clone: Function;
     transform: Function;
@@ -476,16 +476,16 @@ declare class AST_LabeledStatement extends AST_StatementWithBody {
     to_mozilla_ast: Function;
 }
 
-declare class AST_IterationStatement extends AST_StatementWithBody {
+export class AST_IterationStatement extends AST_StatementWithBody {
     clone: Function;
     is_block_scope: Function;
 }
 
-declare class AST_DWLoop extends AST_IterationStatement {
+export class AST_DWLoop extends AST_IterationStatement {
 
 }
 
-declare class AST_Do extends AST_DWLoop {
+export class AST_Do extends AST_DWLoop {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -494,7 +494,7 @@ declare class AST_Do extends AST_DWLoop {
     to_mozilla_ast: Function;
 }
 
-declare class AST_While extends AST_DWLoop {
+export class AST_While extends AST_DWLoop {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -503,7 +503,7 @@ declare class AST_While extends AST_DWLoop {
     to_mozilla_ast: Function;
 }
 
-declare class AST_For extends AST_IterationStatement {
+export class AST_For extends AST_IterationStatement {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -512,7 +512,7 @@ declare class AST_For extends AST_IterationStatement {
     to_mozilla_ast: Function;
 }
 
-declare class AST_ForIn extends AST_IterationStatement {
+export class AST_ForIn extends AST_IterationStatement {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -520,18 +520,18 @@ declare class AST_ForIn extends AST_IterationStatement {
     to_mozilla_ast: Function;
 }
 
-declare class AST_ForOf extends AST_ForIn {
+export class AST_ForOf extends AST_ForIn {
     to_mozilla_ast: Function;
 }
 
-declare class AST_With extends AST_StatementWithBody {
+export class AST_With extends AST_StatementWithBody {
     _walk: Function;
     transform: Function;
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_If extends AST_StatementWithBody {
+export class AST_If extends AST_StatementWithBody {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -543,46 +543,46 @@ declare class AST_If extends AST_StatementWithBody {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Jump extends AST_Statement {
+export class AST_Jump extends AST_Statement {
     add_source_map: Function;
     aborts: Function;
 }
 
-declare class AST_Exit extends AST_Jump {
+export class AST_Exit extends AST_Jump {
     _walk: Function;
     transform: Function;
     _do_print: Function;
 }
 
-declare class AST_Return extends AST_Exit {
+export class AST_Return extends AST_Exit {
     _codegen: Function;
     may_throw: Function;
     optimize: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Throw extends AST_Exit {
+export class AST_Throw extends AST_Exit {
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_LoopControl extends AST_Jump {
+export class AST_LoopControl extends AST_Jump {
     _walk: Function;
     transform: Function;
     _do_print: Function;
 }
 
-declare class AST_Break extends AST_LoopControl {
+export class AST_Break extends AST_LoopControl {
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Continue extends AST_LoopControl {
+export class AST_Continue extends AST_LoopControl {
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Definitions extends AST_Statement {
+export class AST_Definitions extends AST_Statement {
     _walk: Function;
     transform: Function;
     _do_print: Function;
@@ -595,26 +595,26 @@ declare class AST_Definitions extends AST_Statement {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Var extends AST_Definitions {
+export class AST_Var extends AST_Definitions {
     _codegen: Function;
 }
 
-declare class AST_Let extends AST_Definitions {
+export class AST_Let extends AST_Definitions {
     _codegen: Function;
 }
 
-declare class AST_Const extends AST_Definitions {
+export class AST_Const extends AST_Definitions {
     _codegen: Function;
 }
 
-declare class AST_Export extends AST_Statement {
+export class AST_Export extends AST_Statement {
     _walk: Function;
     transform: Function;
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Expansion extends AST_Node {
+export class AST_Expansion extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -623,7 +623,7 @@ declare class AST_Expansion extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Destructuring extends AST_Node {
+export class AST_Destructuring extends AST_Node {
     _walk: Function;
     all_symbols: Function;
     transform: Function;
@@ -632,7 +632,7 @@ declare class AST_Destructuring extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_PrefixedTemplateString extends AST_Node {
+export class AST_PrefixedTemplateString extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -640,7 +640,7 @@ declare class AST_PrefixedTemplateString extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_TemplateString extends AST_Node {
+export class AST_TemplateString extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -652,18 +652,18 @@ declare class AST_TemplateString extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_TemplateSegment extends AST_Node {
+export class AST_TemplateSegment extends AST_Node {
     has_side_effects: Function;
     drop_side_effect_free: Function;
 }
 
-declare class AST_NameMapping extends AST_Node {
+export class AST_NameMapping extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
 }
 
-declare class AST_Import extends AST_Node {
+export class AST_Import extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -672,7 +672,7 @@ declare class AST_Import extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_VarDef extends AST_Node {
+export class AST_VarDef extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -682,7 +682,7 @@ declare class AST_VarDef extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Call extends AST_Node {
+export class AST_Call extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;
@@ -696,7 +696,7 @@ declare class AST_Call extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_New extends AST_Call {
+export class AST_New extends AST_Call {
     needs_parens: Function;
     _codegen: Function;
     add_source_map: Function;
@@ -705,7 +705,7 @@ declare class AST_New extends AST_Call {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Sequence extends AST_Node {
+export class AST_Sequence extends AST_Node {
     _walk: Function;
     transform: Function;
     tail_node: Function;
@@ -724,14 +724,14 @@ declare class AST_Sequence extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_PropAccess extends AST_Node {
+export class AST_PropAccess extends AST_Node {
     needs_parens: Function;
     _eval: Function;
     flatten_object: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Dot extends AST_PropAccess {
+export class AST_Dot extends AST_PropAccess {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -744,7 +744,7 @@ declare class AST_Dot extends AST_PropAccess {
     optimize: Function;
 }
 
-declare class AST_Sub extends AST_PropAccess {
+export class AST_Sub extends AST_PropAccess {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -754,7 +754,7 @@ declare class AST_Sub extends AST_PropAccess {
     optimize: Function;
 }
 
-declare class AST_Unary extends AST_Node {
+export class AST_Unary extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;
@@ -768,7 +768,7 @@ declare class AST_Unary extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_UnaryPrefix extends AST_Unary {
+export class AST_UnaryPrefix extends AST_Unary {
     _codegen: Function;
     _dot_throw: Function;
     is_boolean: Function;
@@ -778,13 +778,13 @@ declare class AST_UnaryPrefix extends AST_Unary {
     optimize: Function;
 }
 
-declare class AST_UnaryPostfix extends AST_Unary {
+export class AST_UnaryPostfix extends AST_Unary {
     _codegen: Function;
     _dot_throw: Function;
     optimize: Function;
 }
 
-declare class AST_Binary extends AST_Node {
+export class AST_Binary extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;
@@ -805,7 +805,7 @@ declare class AST_Binary extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Assign extends AST_Binary {
+export class AST_Assign extends AST_Binary {
     needs_parens: Function;
     reduce_vars: Function;
     _dot_throw: Function;
@@ -819,11 +819,11 @@ declare class AST_Assign extends AST_Binary {
     to_mozilla_ast: Function;
 }
 
-declare class AST_DefaultAssign extends AST_Binary {
+export class AST_DefaultAssign extends AST_Binary {
     optimize: Function;
 }
 
-declare class AST_Conditional extends AST_Node {
+export class AST_Conditional extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;
@@ -842,7 +842,7 @@ declare class AST_Conditional extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Array extends AST_Node {
+export class AST_Array extends AST_Node {
     _walk: Function;
     transform: Function;
     _codegen: Function;
@@ -857,7 +857,7 @@ declare class AST_Array extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Object extends AST_Node {
+export class AST_Object extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;
@@ -873,7 +873,7 @@ declare class AST_Object extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_ObjectProperty extends AST_Node {
+export class AST_ObjectProperty extends AST_Node {
     _walk: Function;
     transform: Function;
     _print_getter_setter: Function;
@@ -887,29 +887,29 @@ declare class AST_ObjectProperty extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_ObjectKeyVal extends AST_ObjectProperty {
+export class AST_ObjectKeyVal extends AST_ObjectProperty {
     _codegen: Function;
     optimize: Function;
 }
 
-declare class AST_ObjectSetter extends AST_ObjectProperty {
+export class AST_ObjectSetter extends AST_ObjectProperty {
     _codegen: Function;
     add_source_map: Function;
 }
 
-declare class AST_ObjectGetter extends AST_ObjectProperty {
+export class AST_ObjectGetter extends AST_ObjectProperty {
     _codegen: Function;
     add_source_map: Function;
     _dot_throw: Function;
 }
 
-declare class AST_ConciseMethod extends AST_ObjectProperty {
+export class AST_ConciseMethod extends AST_ObjectProperty {
     _codegen: Function;
     optimize: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Symbol extends AST_Node {
+export class AST_Symbol extends AST_Node {
     mark_enclosed: Function;
     reference: Function;
     unmangleable: Function;
@@ -923,70 +923,70 @@ declare class AST_Symbol extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_SymbolDeclaration extends AST_Symbol {
+export class AST_SymbolDeclaration extends AST_Symbol {
     _find_defs: Function;
     has_side_effects: Function;
     may_throw: Function;
 }
 
-declare class AST_SymbolVar extends AST_SymbolDeclaration {
+export class AST_SymbolVar extends AST_SymbolDeclaration {
 
 }
 
-declare class AST_SymbolFunarg extends AST_SymbolVar {
+export class AST_SymbolFunarg extends AST_SymbolVar {
 
 }
 
-declare class AST_SymbolBlockDeclaration extends AST_SymbolDeclaration {
+export class AST_SymbolBlockDeclaration extends AST_SymbolDeclaration {
 
 }
 
-declare class AST_SymbolConst extends AST_SymbolBlockDeclaration {
+export class AST_SymbolConst extends AST_SymbolBlockDeclaration {
 
 }
 
-declare class AST_SymbolLet extends AST_SymbolBlockDeclaration {
+export class AST_SymbolLet extends AST_SymbolBlockDeclaration {
 
 }
 
-declare class AST_SymbolDefClass extends AST_SymbolBlockDeclaration {
+export class AST_SymbolDefClass extends AST_SymbolBlockDeclaration {
 
 }
 
-declare class AST_SymbolCatch extends AST_SymbolBlockDeclaration {
+export class AST_SymbolCatch extends AST_SymbolBlockDeclaration {
     reduce_vars: Function;
 }
 
-declare class AST_SymbolImport extends AST_SymbolBlockDeclaration {
+export class AST_SymbolImport extends AST_SymbolBlockDeclaration {
 
 }
 
-declare class AST_SymbolDefun extends AST_SymbolDeclaration {
+export class AST_SymbolDefun extends AST_SymbolDeclaration {
 
 }
 
-declare class AST_SymbolLambda extends AST_SymbolDeclaration {
+export class AST_SymbolLambda extends AST_SymbolDeclaration {
 
 }
 
-declare class AST_SymbolClass extends AST_SymbolDeclaration {
+export class AST_SymbolClass extends AST_SymbolDeclaration {
 
 }
 
-declare class AST_SymbolMethod extends AST_Symbol {
+export class AST_SymbolMethod extends AST_Symbol {
 
 }
 
-declare class AST_SymbolImportForeign extends AST_Symbol {
+export class AST_SymbolImportForeign extends AST_Symbol {
 
 }
 
-declare class AST_Label extends AST_Symbol {
+export class AST_Label extends AST_Symbol {
     initialize: Function;
     unmangleable: Function;
 }
 
-declare class AST_SymbolRef extends AST_Symbol {
+export class AST_SymbolRef extends AST_Symbol {
     reduce_vars: Function;
     is_immutable: Function;
     is_declared: Function;
@@ -999,19 +999,19 @@ declare class AST_SymbolRef extends AST_Symbol {
     optimize: Function;
 }
 
-declare class AST_SymbolExport extends AST_SymbolRef {
+export class AST_SymbolExport extends AST_SymbolRef {
     optimize: Function;
 }
 
-declare class AST_SymbolExportForeign extends AST_Symbol {
+export class AST_SymbolExportForeign extends AST_Symbol {
 
 }
 
-declare class AST_LabelRef extends AST_Symbol {
+export class AST_LabelRef extends AST_Symbol {
 
 }
 
-declare class AST_This extends AST_Symbol {
+export class AST_This extends AST_Symbol {
     _codegen: Function;
     has_side_effects: Function;
     may_throw: Function;
@@ -1019,17 +1019,17 @@ declare class AST_This extends AST_Symbol {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Super extends AST_This {
+export class AST_Super extends AST_This {
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_NewTarget extends AST_Node {
+export class AST_NewTarget extends AST_Node {
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Constant extends AST_Node {
+export class AST_Constant extends AST_Node {
     getValue: Function;
     _codegen: Function;
     add_source_map: Function;
@@ -1042,71 +1042,71 @@ declare class AST_Constant extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_String extends AST_Constant {
+export class AST_String extends AST_Constant {
     _codegen: Function;
     is_string: Function;
 }
 
-declare class AST_Number extends AST_Constant {
+export class AST_Number extends AST_Constant {
     needs_parens: Function;
     _codegen: Function;
     is_number: Function;
 }
 
-declare class AST_RegExp extends AST_Constant {
+export class AST_RegExp extends AST_Constant {
     _codegen: Function;
     optimize: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Atom extends AST_Constant {
+export class AST_Atom extends AST_Constant {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Null extends AST_Atom {
+export class AST_Null extends AST_Atom {
     value: object;
     _dot_throw: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_NaN extends AST_Atom {
+export class AST_NaN extends AST_Atom {
     value: number;
     optimize: Function;
 }
 
-declare class AST_Undefined extends AST_Atom {
+export class AST_Undefined extends AST_Atom {
     value: any;
     _dot_throw: Function;
     optimize: Function;
 }
 
-declare class AST_Hole extends AST_Atom {
+export class AST_Hole extends AST_Atom {
     value: any;
     _codegen: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_Infinity extends AST_Atom {
+export class AST_Infinity extends AST_Atom {
     value: number;
     optimize: Function;
 }
 
-declare class AST_Boolean extends AST_Atom {
+export class AST_Boolean extends AST_Atom {
     optimize: Function;
     to_mozilla_ast: Function;
 }
 
-declare class AST_False extends AST_Boolean {
+export class AST_False extends AST_Boolean {
     value: boolean;
     is_boolean: Function;
 }
 
-declare class AST_True extends AST_Boolean {
+export class AST_True extends AST_Boolean {
     value: boolean;
     is_boolean: Function;
 }
 
-declare class AST_Await extends AST_Node {
+export class AST_Await extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;
@@ -1114,7 +1114,7 @@ declare class AST_Await extends AST_Node {
     to_mozilla_ast: Function;
 }
 
-declare class AST_Yield extends AST_Node {
+export class AST_Yield extends AST_Node {
     _walk: Function;
     transform: Function;
     needs_parens: Function;

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -115,7 +115,7 @@ export interface OutputOptions {
     indent_level?: number;
     indent_start?: boolean;
     inline_script?: boolean;
-    is8?: boolean;
+    ie8?: boolean;
     keep_quoted_props?: boolean;
     max_line_len?: boolean;
     preamble?: string;

--- a/tools/node.d.ts
+++ b/tools/node.d.ts
@@ -161,12 +161,13 @@ declare class NodeElement {
     TYPE: string;
     documentation: string;
     propdoc?: Record<string, string>;
+    expressions?: NodeElement[];
     warn?: (text: string, props: any) => void;
     from_mozilla_ast?: (node: NodeElement) => any;
 }
 
 export class TreeWalker {
-    constructor(callback: Function);
+    constructor(callback: (node: NodeElement, descend: boolean) => NodeElement);
     directives: object;
     find_parent(type: NodeElement): NodeElement | undefined;
     has_directive(type: string): boolean;
@@ -176,7 +177,13 @@ export class TreeWalker {
     push(node: NodeElement): void;
     self(): NodeElement | undefined;
     stack: NodeElement[];
-    visit: Function;
+    visit: (node: NodeElement, descend: boolean) => NodeElement;
+}
+
+export class TreeTransformer extends TreeWalker {
+    constructor(before: (node: NodeElement) => NodeElement, after?: (node: NodeElement) => NodeElement);
+    before: (node: NodeElement) => NodeElement;
+    after?: (node: NodeElement) => NodeElement;
 }
 
 export function push_uniq<T>(array: T[], el: T): void;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -67,6 +67,7 @@ export enum InlineFunctions {
     WithArguments = 2,
     WithArgumentsAndVariables = 3
 }
+
 export interface MangleOptions {
     eval?: boolean;
     keep_classnames?: boolean | RegExp;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -206,9 +206,9 @@ export class AST_Node {
     static expressions?: AST_Node[];
     static warn?: (text: string, props: any) => void;
     static from_mozilla_ast?: (node: AST_Node) => any;
-    walk(visitor: TreeWalker);
+    walk: (visitor: TreeWalker) => void;
     print_to_string: (options?: OutputOptions) => string;
-    transform: (tt: TreeTransformer, in_list: boolean) => AST_Node;
+    transform: (tt: TreeTransformer, in_list?: boolean) => AST_Node;
     TYPE: string;
     CTOR: typeof AST_Node;
 }
@@ -411,7 +411,7 @@ declare class AST_With extends AST_StatementWithBody {
 declare class AST_If extends AST_StatementWithBody {
     constructor(props?: object);
     condition: AST_Node;
-    alternative: AST_Node;
+    alternative: AST_Node | null;
 }
 
 declare class AST_Jump extends AST_Statement {
@@ -579,7 +579,7 @@ declare class AST_Conditional extends AST_Node {
     constructor(props?: object);
     condition: AST_Node;
     consequent: AST_Node;
-    alternative: AST_Node | null;
+    alternative: AST_Node;
 }
 
 declare class AST_Array extends AST_Node {

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -154,7 +154,7 @@ export interface SourceMapOptions {
 declare function parse(text: string, options?: ParseOptions): AST_Node;
 
 export class TreeWalker {
-    constructor(callback: (node: AST_Node, descend: boolean) => any);
+    constructor(callback: (node: AST_Node, descend?: (node: AST_Node) => void) => boolean | undefined);
     directives: object;
     find_parent(type: AST_Node): AST_Node | undefined;
     has_directive(type: string): boolean;
@@ -168,7 +168,10 @@ export class TreeWalker {
 }
 
 export class TreeTransformer extends TreeWalker {
-    constructor(before: (node: AST_Node) => AST_Node, after?: (node: AST_Node) => AST_Node);
+    constructor(
+        before: (node: AST_Node, descend?: (node: AST_Node, tw: TreeWalker) => void, in_list?: boolean) => AST_Node | undefined,
+        after?: (node: AST_Node, in_list?: boolean) => AST_Node | undefined
+    );
     before: (node: AST_Node) => AST_Node;
     after?: (node: AST_Node) => AST_Node;
 }
@@ -203,7 +206,9 @@ export class AST_Node {
     static expressions?: AST_Node[];
     static warn?: (text: string, props: any) => void;
     static from_mozilla_ast?: (node: AST_Node) => any;
-    print_to_string(options?: OutputOptions);
+    walk(visitor: TreeWalker);
+    print_to_string: (options?: OutputOptions) => string;
+    transform: (tt: TreeTransformer, in_list: boolean) => AST_Node;
     TYPE: string;
     CTOR: typeof AST_Node;
 }
@@ -406,7 +411,7 @@ declare class AST_With extends AST_StatementWithBody {
 declare class AST_If extends AST_StatementWithBody {
     constructor(props?: object);
     condition: AST_Node;
-    alternative: AST_Node | null;
+    alternative: AST_Node;
 }
 
 declare class AST_Jump extends AST_Statement {


### PR DESCRIPTION
I just added TS definitions to use it with TypeScript.
Definitions were copied from uglify-js.

- [x] Sort interface props
- [x] Add Dictionary class types
- [x] Add parse types
- [x] Add push_uniq types
- [x] Add TreeTransformer types
- [x] Add TreeWalker types
- [x] Add correct Node ast types