### PR TITLE
Accept regex in mangle keep options

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,12 +531,13 @@ if (result.error) throw result.error;
 - `ie8` (default `false`) - set to `true` to support IE8.
 
 - `keep_classnames` (default: `undefined`) - pass `true` to prevent discarding or mangling
-  of class names.
+  of class names. Pass a regular expression to only keep class names matching that regex.
 
 - `keep_fnames` (default: `false`) - pass `true` to prevent discarding or mangling
-  of function names.  Useful for code relying on `Function.prototype.name`. If the
-  top level minify option `keep_classnames` is `undefined` it will be overridden with
-  the value of the top level minify option `keep_fnames`.
+  of function names. Pass a regular expression to only keep class names matching that regex.
+  Useful for code relying on `Function.prototype.name`. If the top level minify option
+  `keep_classnames` is `undefined` it will be overridden with the value of the top level
+  minify option `keep_fnames`.
 
 - `safari10` (default: `false`) - pass `true` to work around Safari 10/11 bugs in
   loop scoping and `await`. See `safari10` options in [`mangle`](#mangle-options)
@@ -712,16 +713,17 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 
 - `join_vars` (default: `true`) -- join consecutive `var` statements
 
-- `keep_classnames` (default: `false`) -- Pass `true` to prevent the
-  compressor from discarding class names.  See also: the `keep_classnames`
-  [mangle option](#mangle).
+- `keep_classnames` (default: `false`) -- Pass `true` to prevent the compressor from
+  discarding class names. Pass a regular expression to only keep class names matching
+  that regex. See also: the `keep_classnames` [mangle option](#mangle).
 
 - `keep_fargs` (default: `true`) -- Prevents the compressor from discarding unused
   function arguments.  You need this for code which relies on `Function.length`.
 
 - `keep_fnames` (default: `false`) -- Pass `true` to prevent the
-  compressor from discarding function names.  Useful for code relying on
-  `Function.prototype.name`. See also: the `keep_fnames` [mangle option](#mangle).
+  compressor from discarding function names. Pass a regular expression to only keep
+  class names matching that regex. Useful for code relying on `Function.prototype.name`.
+  See also: the `keep_fnames` [mangle option](#mangle).
 
 - `keep_infinity` (default: `false`) -- Pass `true` to prevent `Infinity` from
   being compressed into `1/0`, which may cause performance issues on Chrome.
@@ -848,9 +850,11 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   where `eval` or `with` are used.
 
 - `keep_classnames` (default `false`) -- Pass `true` to not mangle class names.
+  Pass a regular expression to only keep class names matching that regex.
   See also: the `keep_classnames` [compress option](#compress-options).
 
 - `keep_fnames` (default `false`) -- Pass `true` to not mangle function names.
+  Pass a regular expression to only keep class names matching that regex.
   Useful for code relying on `Function.prototype.name`. See also: the `keep_fnames`
   [compress option](#compress-options).
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -68,11 +68,11 @@ SymbolDef.prototype = {
             || this.export
             || this.undeclared
             || !options.eval && this.scope.pinned()
-            || (options.keep_fnames === true || options.keep_fnames instanceof RegExp && options.keep_fnames.test(this.orig[0].name))
+            || (options.keep_fnames instanceof RegExp && options.keep_fnames.test(this.orig[0].name) || options.keep_fnames === true)
                 && (this.orig[0] instanceof AST_SymbolLambda
                     || this.orig[0] instanceof AST_SymbolDefun)
             || this.orig[0] instanceof AST_SymbolMethod
-            || (options.keep_classnames === true || options.keep_classnames instanceof RegExp && options.keep_classnames.test(this.orig[0].name))
+            || (options.keep_classnames instanceof RegExp && options.keep_classnames.test(this.orig[0].name) || options.keep_classnames === true)
                 && (this.orig[0] instanceof AST_SymbolClass
                     || this.orig[0] instanceof AST_SymbolDefClass);
     },

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -68,11 +68,11 @@ SymbolDef.prototype = {
             || this.export
             || this.undeclared
             || !options.eval && this.scope.pinned()
-            || options.keep_fnames
+            || (options.keep_fnames === true || options.keep_fnames instanceof RegExp && options.keep_fnames.test(this.orig[0].name))
                 && (this.orig[0] instanceof AST_SymbolLambda
                     || this.orig[0] instanceof AST_SymbolDefun)
             || this.orig[0] instanceof AST_SymbolMethod
-            || options.keep_classnames
+            || (options.keep_classnames === true || options.keep_classnames instanceof RegExp && options.keep_classnames.test(this.orig[0].name))
                 && (this.orig[0] instanceof AST_SymbolClass
                     || this.orig[0] instanceof AST_SymbolDefClass);
     },

--- a/test/compress/keep_names.js
+++ b/test/compress/keep_names.js
@@ -1,0 +1,108 @@
+drop_fnames: {
+  mangle = {
+    keep_fnames : false,
+  };
+  input: {
+    function foo() {
+      function bar() {
+        return "foobar";
+      }
+    }
+  }
+  expect: {
+    function foo() {
+      function o() {
+        return "foobar";
+      }
+    }
+  }
+}
+
+keep_fnames: {
+  mangle = {
+    keep_fnames: true,
+  };
+  input: {
+    function foo() {
+      function bar() {
+        return "foobar";
+      }
+    }
+  }
+  expect: {
+    function foo() {
+      function bar() {
+        return "foobar";
+      }
+    }
+  }
+}
+
+drop_classnames: {
+  mangle = {
+    keep_classnames : false,
+  };
+  input: {
+    function foo() {
+      class Bar {}
+    }
+  }
+  expect: {
+    function foo() {
+      class o {}
+    }
+  }
+}
+
+keep_classnames: {
+  mangle = {
+    keep_classnames: true,
+  };
+  input: {
+    function foo() {
+      class Bar {}
+    }
+  }
+  expect: {
+    function foo() {
+      class Bar {}
+    }
+  }
+}
+
+keep_some_fnames: {
+  mangle = {
+    keep_fnames: /^[A-Za-z]*Element$/,
+  };
+  input: {
+    function foo() {
+      function bar() {}
+      function barElement() {}
+    }
+  }
+  expect: {
+    function foo() {
+      function n() {}
+      function barElement() {}
+    }
+  }
+}
+
+keep_some_classnames: {
+  mangle = {
+    keep_classnames: /^[A-Za-z]*Element$/,
+  };
+  input: {
+    function foo() {
+      class Bar {}
+      class BarElement {}
+    }
+  }
+  expect: {
+    function foo() {
+      class s {}
+      class BarElement {}
+    }
+  }
+}
+


### PR DESCRIPTION
Hey there 👋 

I want to only keep certain function and class names in my bundles so that our error reporting software will report errors correctly when calling `Function.prototype.name`. Setting `keep_fnames: true` adds too much unwanted data.

This PR allows users to pass a regular expression to `keep_fnames` and `keep_classnames` and will only mangle class names and functions that don't match that regular expression.

Maybe there are too much redundancy in the tests since I figure the `keep_fnames` and `keep_classnames` are already being testing somewhere else. Let me know I'll delete those tests and only keep the `keep_some_*` tests.

✨ 