### PR TITLE
Fix `keep_fnames` regex use in combination with `reduce_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3430,10 +3430,12 @@ merge(Compressor.prototype, {
                     }
                 }
                 if (scope !== self) return;
+                var def;
                 if (node.name
-                    && (!compressor.option("keep_classnames") && node instanceof AST_ClassExpression
-                        || !compressor.option("keep_fnames") && node instanceof AST_Function)) {
-                    var def = node.name.definition();
+                    && (node instanceof AST_ClassExpression
+                        && !keep_name(compressor.option("keep_classnames"), (def = node.name.definition()).name)
+                    || node instanceof AST_Function
+                        && !keep_name(compressor.option("keep_fnames"), (def = node.name.definition()).name))) {
                     // any declarations with same name will overshadow
                     // name of this anonymous function and can therefore
                     // never be used anywhere

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -68,13 +68,11 @@ SymbolDef.prototype = {
             || this.export
             || this.undeclared
             || !options.eval && this.scope.pinned()
-            || (options.keep_fnames instanceof RegExp && options.keep_fnames.test(this.orig[0].name) || options.keep_fnames === true)
-                && (this.orig[0] instanceof AST_SymbolLambda
-                    || this.orig[0] instanceof AST_SymbolDefun)
+            || (this.orig[0] instanceof AST_SymbolLambda
+                  || this.orig[0] instanceof AST_SymbolDefun) && keep_name(options.keep_fnames, this.orig[0].name)
             || this.orig[0] instanceof AST_SymbolMethod
-            || (options.keep_classnames instanceof RegExp && options.keep_classnames.test(this.orig[0].name) || options.keep_classnames === true)
-                && (this.orig[0] instanceof AST_SymbolClass
-                    || this.orig[0] instanceof AST_SymbolDefClass);
+            || (this.orig[0] instanceof AST_SymbolClass
+                  || this.orig[0] instanceof AST_SymbolDefClass) && keep_name(options.keep_classnames, this.orig[0].name);
     },
     mangle: function(options) {
         var cache = options.cache && options.cache.props;
@@ -387,7 +385,9 @@ AST_Symbol.DEFMETHOD("mark_enclosed", function(options) {
         push_uniq(s.enclosed, def);
         if (options.keep_fnames) {
             s.functions.each(function(d) {
-                push_uniq(def.scope.enclosed, d);
+                if (keep_name(options.keep_fnames, d.name)) {
+                    push_uniq(def.scope.enclosed, d);
+                }
             });
         }
         if (s === def.scope) break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -342,3 +342,8 @@ function first_in_statement(stack) {
         }
     }
 }
+
+function keep_name(keep_setting, name) {
+    return keep_setting === true
+        || (keep_setting instanceof RegExp && keep_setting.test(name));
+}

--- a/test/compress/keep_names.js
+++ b/test/compress/keep_names.js
@@ -1,108 +1,135 @@
 drop_fnames: {
-  mangle = {
-    keep_fnames : false,
-  };
-  input: {
-    function foo() {
-      function bar() {
-        return "foobar";
-      }
+    mangle = {
+        keep_fnames : false,
     }
-  }
-  expect: {
-    function foo() {
-      function o() {
-        return "foobar";
-      }
+    input: {
+        function foo() {
+            function bar() {
+                return "foobar";
+            }
+        }
     }
-  }
+    expect: {
+        function foo() {
+            function o() {
+                return "foobar";
+            }
+        }
+    }
 }
 
 keep_fnames: {
-  mangle = {
-    keep_fnames: true,
-  };
-  input: {
-    function foo() {
-      function bar() {
-        return "foobar";
-      }
+    mangle = {
+        keep_fnames: true,
     }
-  }
-  expect: {
-    function foo() {
-      function bar() {
-        return "foobar";
-      }
+    input: {
+        function foo() {
+            function bar() {
+                return "foobar";
+            }
+        }
     }
-  }
+    expect: {
+        function foo() {
+            function bar() {
+                return "foobar";
+            }
+        }
+    }
 }
 
 drop_classnames: {
-  mangle = {
-    keep_classnames : false,
-  };
-  input: {
-    function foo() {
-      class Bar {}
+    mangle = {
+        keep_classnames : false,
     }
-  }
-  expect: {
-    function foo() {
-      class o {}
+    input: {
+        function foo() {
+            class Bar {}
+        }
     }
-  }
+    expect: {
+        function foo() {
+            class o {}
+        }
+    }
 }
 
 keep_classnames: {
-  mangle = {
-    keep_classnames: true,
-  };
-  input: {
-    function foo() {
-      class Bar {}
+    mangle = {
+        keep_classnames: true,
     }
-  }
-  expect: {
-    function foo() {
-      class Bar {}
+    input: {
+        function foo() {
+            class Bar {}
+        }
     }
-  }
+    expect: {
+        function foo() {
+            class Bar {}
+        }
+    }
 }
 
 keep_some_fnames: {
-  mangle = {
-    keep_fnames: /^[A-Za-z]*Element$/,
-  };
-  input: {
-    function foo() {
-      function bar() {}
-      function barElement() {}
+    mangle = {
+        keep_fnames: /Element$/,
     }
-  }
-  expect: {
-    function foo() {
-      function n() {}
-      function barElement() {}
+    input: {
+        function foo() {
+            function bar() {}
+            function barElement() {}
+        }
     }
-  }
+    expect: {
+        function foo() {
+            function n() {}
+            function barElement() {}
+        }
+    }
+}
+
+keep_some_fnames_reduce: {
+    options = {
+        reduce_vars: true,
+        unused: true,
+        keep_fnames: /Element$/,
+    }
+    mangle = {
+        keep_fnames: /Element$/,
+    }
+    input: {
+        function foo() {
+            var array = [];
+            function bar() {}
+            array.map(bar);
+            function barElement() {}
+            array.map(barElement);
+        }
+    }
+    expect: {
+        function foo() {
+            var n = [];
+            n.map(function() {});
+            n.map(function barElement() {});
+        }
+    }
 }
 
 keep_some_classnames: {
-  mangle = {
-    keep_classnames: /^[A-Za-z]*Element$/,
-  };
-  input: {
-    function foo() {
-      class Bar {}
-      class BarElement {}
+    mangle = {
+        keep_classnames: /Element$/,
     }
-  }
-  expect: {
-    function foo() {
-      class s {}
-      class BarElement {}
+    input: {
+        function foo() {
+            class Bar {}
+            class BarElement {}
+        }
     }
-  }
+    expect: {
+        function foo() {
+            class s {}
+            class BarElement {}
+        }
+    }
 }
 


### PR DESCRIPTION
Use case:

```js
minify(code, { keep_fnames: /regex/ })
```

The regex gets forwarded to both `mangle` and `compress` options. Respecting the regex was implemented within `mangle`, but in other places the value was still treated like a boolean.

This resulted in functions which would otherwise be anonymized still having a name:

```js
a.map(function n() { ... })
```

where in fact the correct compression should have been:

```js
a.map(function() { ... })
```

Followup to #125 /cc @koddsson 