### PR TITLE
remove some node versions to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
     - "0.10"
-    - "0.12"
     - "4"
-    - "6"
     - "8"
     - "10"
 env:

--- a/test/mocha/release.js
+++ b/test/mocha/release.js
@@ -13,10 +13,8 @@ function run(command, args, done) {
     });
 }
 
-if (semver.satisfies(process.version, "0.12")) return;
 if (semver.satisfies(process.version, "0.10")) return;
 if (semver.satisfies(process.version, "4")) return;
-if (semver.satisfies(process.version, "6")) return;
 
 describe("test/benchmark.js", function() {
     this.timeout(10 * 60 * 1000);

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -74,14 +74,6 @@ exports.run_code = function(code) {
         process.stdout.write = original_write;
     }
 };
-exports.same_stdout = semver.satisfies(process.version, "0.12") ? function(expected, actual) {
-    if (typeof expected != typeof actual) return false;
-    if (typeof expected != "string") {
-        if (expected.name != actual.name) return false;
-        expected = expected.message.slice(expected.message.lastIndexOf("\n") + 1);
-        actual = actual.message.slice(actual.message.lastIndexOf("\n") + 1);
-    }
-    return strip_func_ids(expected) == strip_func_ids(actual);
-} : function(expected, actual) {
+exports.same_stdout = function(expected, actual) {
     return typeof expected == typeof actual && strip_func_ids(expected) == strip_func_ids(actual);
 };


### PR DESCRIPTION
It also simplifies some code.

@kzc what do you think?

edit: I don't think you'll ever find bugs in *only* either of these removed versions. A bug that manifested in 0.12 would also show up in 0.10, and a bug in 6 would also show up in 4 and 8.