### PR TITLE
fix loop `inline` bug - cannot read property _walk of null

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4926,7 +4926,7 @@ merge(Compressor.prototype, {
             stat = null;
             for (var i = 0; i < len; i++) {
                 var line = body[i];
-                if (line instanceof AST_Var) {
+                if (line instanceof AST_Definitions) {
                     if (stat && !all(line.definitions, function(var_def) {
                         return !var_def.value;
                     })) {
@@ -4941,7 +4941,7 @@ merge(Compressor.prototype, {
             return return_value(stat);
         }
 
-        function can_inject_args(block_scoped, safe_to_inject) {
+        function can_inject_args(block_scoped, defs, safe_to_inject) {
             for (var i = 0, len = fn.argnames.length; i < len; i++) {
                 var arg = fn.argnames[i];
                 if (arg instanceof AST_DefaultAssign) {
@@ -4969,7 +4969,7 @@ merge(Compressor.prototype, {
             var len = fn.body.length;
             for (var i = 0; i < len; i++) {
                 var stat = fn.body[i];
-                if (!(stat instanceof AST_Var)) continue;
+                if (!(stat instanceof AST_Definitions)) continue;
                 if (!safe_to_inject) return false;
                 for (var j = stat.definitions.length; --j >= 0;) {
                     var name = stat.definitions[j].name;
@@ -5010,8 +5010,8 @@ merge(Compressor.prototype, {
             } while (!(scope instanceof AST_Scope) || scope instanceof AST_Arrow);
             var safe_to_inject = !(scope instanceof AST_Toplevel) || compressor.toplevel.vars;
             var inline = compressor.option("inline");
-            if (!can_inject_vars(block_scoped, inline >= 3 && safe_to_inject)) return false;
-            if (!can_inject_args(block_scoped, inline >= 2 && safe_to_inject)) return false;
+            if (!can_inject_vars(block_scoped, !in_loop && inline >= 3 && safe_to_inject)) return false;
+            if (!can_inject_args(block_scoped, in_loop, inline >= 2 && safe_to_inject)) return false;
             return !in_loop || in_loop.length == 0 || !is_reachable(fn, in_loop);
         }
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4926,7 +4926,7 @@ merge(Compressor.prototype, {
             stat = null;
             for (var i = 0; i < len; i++) {
                 var line = body[i];
-                if (line instanceof AST_Definitions) {
+                if (line instanceof AST_Var) {
                     if (stat && !all(line.definitions, function(var_def) {
                         return !var_def.value;
                     })) {
@@ -4969,7 +4969,7 @@ merge(Compressor.prototype, {
             var len = fn.body.length;
             for (var i = 0; i < len; i++) {
                 var stat = fn.body[i];
-                if (!(stat instanceof AST_Definitions)) continue;
+                if (!(stat instanceof AST_Var)) continue;
                 if (!safe_to_inject) return false;
                 for (var j = stat.definitions.length; --j >= 0;) {
                     var name = stat.definitions[j].name;

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -1155,8 +1155,9 @@ issue_2749: {
     expect: {
         var a = 2, c = "PASS";
         while (a--)
-            b = void 0, b ? c = "FAIL" : b = 1;
-        var b;
+            (function(){
+                return b?c="FAIL":b=1;var b
+            })();
         console.log(c);
     }
     expect_stdout: "PASS"

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -2087,8 +2087,9 @@ use_before_init_in_loop: {
     expect: {
         var a = "PASS";
         for (var b = 2; --b >= 0;)
-            c = void 0, c = (c && (a = "FAIL"), 1);
-        var c;
+            (function() {
+                var c = (c && (a="FAIL"), 1);
+            })();
         console.log(a);
     }
     expect_stdout: "PASS"
@@ -2238,8 +2239,11 @@ issue_2898: {
     expect: {
         var c = 0;
         (function() {
-            while (b = void 0, void ((b = void (c = 1 + (c = 1 + c))) && b[0]));
-            var b;
+            while (f());
+            function f() {
+                var b = void (c = 1 + (c = 1 + c));
+                b && b[0];
+            }
         })(),
         console.log(c);
     }
@@ -2295,10 +2299,11 @@ issue_3016_1: {
     expect: {
         var b = 1;
         do {
-            a = 3,
-            a[b];
+            (function(a) {
+                return a[b];
+                var a
+            })(3);
         } while(0);
-        var a;
         console.log(b);
     }
     expect_stdout: "1"
@@ -2327,10 +2332,11 @@ issue_3016_2: {
     expect: {
         var b = 1;
         do {
-            a = 3,
-            a[b];
+            (function(a) {
+                return a[b];
+                var a
+            })(3);
         } while(0);
-        var a;
         console.log(b);
     }
     expect_stdout: "1"
@@ -2360,10 +2366,11 @@ issue_3016_2_ie8: {
     expect: {
         var b = 1;
         do {
-            a = 3,
-            a[b];
+            (function(a) {
+                return a[b];
+                var a
+            })(3);
         } while(0);
-        var a;
         console.log(b);
     }
     expect_stdout: "1"
@@ -2391,9 +2398,8 @@ issue_3016_3: {
     expect: {
         var b = 1;
         do {
-            console.log((a = void 0, a ? "FAIL" : a = "PASS"));
+            console.log(function () {return a ? "FAIL" : a = "PASS";var a}());
         } while(b--);
-        var a;
     }
     expect_stdout: [
         "PASS",
@@ -2424,9 +2430,8 @@ issue_3016_3_ie8: {
     expect: {
         var b = 1;
         do {
-            console.log((a = void 0, a ? "FAIL" : a = "PASS"));
+            console.log(function () {return a ? "FAIL" : a = "PASS";var a}());
         } while(b--);
-        var a;
     }
     expect_stdout: [
         "PASS",
@@ -2454,10 +2459,8 @@ issue_3018: {
     expect: {
         var b = 1, c = "PASS";
         do {
-            a = void 0,
-            a = 0 != (a && (c = "FAIL"));
+            (function(){a=0!=(a&&(c="FAIL")); var a})()
         } while (b--);
-        var a;
         console.log(c);
     }
     expect_stdout: "PASS"
@@ -2512,8 +2515,7 @@ issue_3076: {
         var c = "PASS";
         (function(b) {
             var n = 2;
-            while (--b + (e = void 0, e && (c = "FAIL"), e = 5, 1).toString() && --n > 0);
-            var e;
+            while (--b + function(){return e && (c="FAIL"), e= 5, 1; var e}().toString() && --n > 0);
         })(2),
         console.log(c);
     }

--- a/test/compress/issue-120.js
+++ b/test/compress/issue-120.js
@@ -1,0 +1,14 @@
+
+issue_120: {
+    input: {
+        function f(){for(var t=o=>{var i=+o;return i+i};t(););}
+    }
+    expect_exact: "function f(){for(var t=o=>{var i=+o;return i+i};t(););}"
+}
+
+issue_120_2: {
+    input: {
+        for(var t=o=>{var i=+o;return i+i};t(););
+    }
+    expect_exact: "for(var t=o=>{var i=+o;return i+i};t(););"
+}

--- a/test/compress/issue-120.js
+++ b/test/compress/issue-120.js
@@ -1,5 +1,9 @@
 
 issue_120: {
+    options = {
+        defaults: true,
+        inline: 3
+    }
     input: {
         function f(){for(var t=o=>{var i=+o;return i+i};t(););}
     }
@@ -7,8 +11,66 @@ issue_120: {
 }
 
 issue_120_2: {
+    options = {
+        defaults: true,
+        inline: 3
+    }
     input: {
         for(var t=o=>{var i=+o;return i+i};t(););
     }
     expect_exact: "for(var t=o=>{var i=+o;return i+i};t(););"
+}
+
+issue_120_3: {
+    options = {
+        collapse_vars: true,
+        evaluate: true,
+        inline: 3,
+        join_vars: true,
+        loops: true,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        function foo(node) {
+            var traverse = function(obj) {
+                var i = obj.data;
+                return i && i.a != i.b;
+            };
+            while (traverse(node)) {
+                node = node.data;
+            }
+            return node;
+        }
+        var x = {
+            a: 1,
+            b: 2,
+            data: {
+                a: "hello",
+            }
+        };
+        console.log(foo(x).a, foo({a : "world"}).a);
+    }
+    expect: {
+        function foo(node) {
+            for (var traverse = function(obj) {
+                var i = obj.data;
+                return i && i.a != i.b;
+            }; traverse(node); ) node = node.data;
+            return node;
+        }
+        var x = {
+            a: 1,
+            b: 2,
+            data: {
+                a: "hello"
+            }
+        };
+        console.log(foo(x).a, foo({
+            a: "world"
+        }).a);
+    }
+    expect_stdout: "hello world"
 }


### PR DESCRIPTION
This fixes the "cannot read property _walk of null" error.