### PR TITLE
Make tests compatible with Node.js 12 and prerelease versions

### DIFF
--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1406,12 +1406,12 @@ self_comparison_1: {
     }
     input: {
         var o = { n: NaN };
-        console.log(o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n, typeof o.n);
+        console.log(typeof o.n, o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n);
     }
     expect: {
-        console.log(false, false, true, true, "number");
+        console.log("number", false, false, true, true);
     }
-    expect_stdout: "false false true true 'number'"
+    expect_stdout: "number false false true true"
 }
 
 self_comparison_2: {
@@ -1426,12 +1426,12 @@ self_comparison_2: {
     }
     input: {
         var o = { n: NaN };
-        console.log(o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n, typeof o.n);
+        console.log(typeof o.n, o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n);
     }
     expect: {
-        console.log(false, false, true, true, "number");
+        console.log("number", false, false, true, true);
     }
-    expect_stdout: "false false true true 'number'"
+    expect_stdout: "number false false true true"
 }
 
 issue_2535_1: {

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2724,7 +2724,7 @@ issue_1814_2: {
         !function() {
             var b = a + 1;
             !function(a) {
-                console.log(a++, b);
+                console.log(b, a++);
             }(0);
         }();
     }
@@ -2732,11 +2732,11 @@ issue_1814_2: {
         const a = "32";
         !function() {
             !function(a) {
-                console.log(a++, "321");
+                console.log("321", a++);
             }(0);
         }();
     }
-    expect_stdout: "0 '321'"
+    expect_stdout: "321 0"
 }
 
 try_abort: {

--- a/test/compress/string-literal.js
+++ b/test/compress/string-literal.js
@@ -15,14 +15,14 @@ issue_1929: {
             return s.split(/[\\/]/);
         }
         var r = f("A/B\\C\\D/E\\F");
-        console.log(r.length, r[5], r[4], r[3], r[2], r[1], r[0]);
+        console.log(r[5], r[4], r[3], r[2], r[1], r[0], r.length);
     }
     expect: {
         function f(s) {
             return s.split(/[\\/]/);
         }
         var r = f("A/B\\C\\D/E\\F");
-        console.log(r.length, r[5], r[4], r[3], r[2], r[1], r[0]);
+        console.log(r[5], r[4], r[3], r[2], r[1], r[0], r.length);
     }
-    expect_stdout: "6 'F' 'E' 'D' 'C' 'B' 'A'"
+    expect_stdout: "F E D C B A 6"
 }

--- a/tools/colorless-console.js
+++ b/tools/colorless-console.js
@@ -1,8 +1,6 @@
 "use strict"
 
-var semver = require("semver");
-
-if (semver.satisfies(process.version, ">=10")) {
+if (Number((/([0-9]+)\./.exec(process.version) || [])[1]) >= 10) {
     var Console = require("console").Console;
     global.console = new Console({
         stdout: process.stdout,


### PR DESCRIPTION
Two commits here to make the tests compatible with Node.js 12 as well as prerelease versions of Node.js.

First, the output semantics of `console.log` for cases of non-string first argument will change which breaks a few output expectations in the tests. I made the tests compatible with any Node.js version by ensuring that the first argument is a string, in which case the output will be the same in all versions.

Additionally, the first commit makes the version check of `tools/colorless-console.js` compatible with prerelease versions of Node.js.

Related:

- https://github.com/nodejs/node/pull/23162
- https://github.com/nodejs/node/issues/25060
- https://github.com/mishoo/UglifyJS2/pull/3304
