### PR TITLE
Fix #207, drop support for Node versions <4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - iojs
   - 4
   - 6
   - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
     - 6
     - 8
     - 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
-    - 6
-    - 8
-    - 10
-    - 11
+  - iojs
+  - 4
+  - 6
+  - 8
+  - 10
+  - 11
 env:
-    - UGLIFYJS_TEST_ALL=1 TRAVIS=1
+  - UGLIFYJS_TEST_ALL=1 TRAVIS=1
 matrix:
   fast_finish: true
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-2-Clause",
   "version": "3.13.1",
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=4.0.0"
   },
   "maintainers": [
     "Fábio Santos <fabiosantosart@gmail.com>",

--- a/test/compress/arrow.js
+++ b/test/compress/arrow.js
@@ -232,7 +232,6 @@ async_identifiers: {
         "async 1",
         "await 2",
     ]
-    node_version: ">=4"
 }
 
 async_function_expression: {
@@ -323,7 +322,6 @@ issue_2105_1: {
         }).prop();
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 issue_2105_2: {
@@ -534,7 +532,6 @@ issue_2084: {
         console.log(c);
     }
     expect_stdout: "0"
-    node_version: ">=4"
 }
 
 export_default_object_expression: {
@@ -567,7 +564,6 @@ concise_methods_with_computed_property2: {
     }
     expect_exact: 'var foo={[[1]]:v=>v};console.log(foo[[1]]("PASS"));'
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 async_object_literal: {
@@ -652,7 +648,6 @@ concise_method_with_super: {
         console.log(o.g());
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 issue_3092a: {

--- a/test/compress/async.js
+++ b/test/compress/async.js
@@ -243,7 +243,6 @@ async_shorthand_property: {
         "Async Await",
         "Async Await",
     ]
-    node_version: ">=4"
 }
 
 async_arrow: {

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -2939,7 +2939,6 @@ issue_2203_3: {
         }.b());
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 issue_2203_4: {
@@ -2970,7 +2969,6 @@ issue_2203_4: {
         }.b());
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 duplicate_argname: {

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -100,7 +100,6 @@ dead_code_2_should_warn_strict: {
         f();
     }
     expect_stdout: true
-    node_version: ">=4"
     reminify: false // FIXME - block scoped function
 }
 
@@ -173,7 +172,6 @@ dead_code_constant_boolean_should_warn_more_strict: {
         bar();
     }
     expect_stdout: true
-    node_version: ">=4"
     reminify: false // FIXME - block scoped function
 }
 

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -251,7 +251,6 @@ hoist_funs_strict: {
         "5 'function' 'function'",
         "6 'undefined' 'function'",
     ]
-    node_version: ">=4"
 }
 
 issue_203: {
@@ -1523,7 +1522,6 @@ issue_2647_2: {
         }());
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 issue_2647_3: {
@@ -1549,7 +1547,6 @@ issue_2647_3: {
         })();
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 recursive_inline_1: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -23,7 +23,6 @@ typeof_arrow_functions: {
     }
     expect_exact: "var foo=\"function\";console.log(foo);"
     expect_stdout: "function"
-    node_version: ">=4"
 }
 
 classes: {
@@ -975,7 +974,6 @@ shorthand_keywords: {
     }
     expect_exact: "var foo=0,async=1,await=2,implements=3,package=4,private=5,protected=6,static=7,yield=8;console.log({foo,0:0,NaN:NaN,async,await,false:false,implements:implements,null:null,package:package,private:private,protected:protected,static:static,this:this,true:true,undefined:void 0,yield});"
     expect_stdout: true
-    node_version: ">=4"
 }
 
 array_literal_with_spread_1: {

--- a/test/compress/if_return.js
+++ b/test/compress/if_return.js
@@ -382,7 +382,6 @@ issue_1317_strict: {
         }();
     }
     expect_stdout: "1"
-    node_version: ">=4"
 }
 
 if_var_return: {
@@ -488,5 +487,4 @@ issue_2747: {
         console.log(f(0), f(1), f(3));
     }
     expect_stdout: "null 5 4"
-    node_version: ">=4"
 }

--- a/test/compress/node_version.js
+++ b/test/compress/node_version.js
@@ -23,16 +23,3 @@ eval_let_4: {
     expect_stdout: SyntaxError("Block-scoped declarations (let, const, function, class) not yet supported outside strict mode")
     node_version: "4"
 }
-
-eval_let_0: {
-    input: {
-        eval("let a;");
-        console.log();
-    }
-    expect: {
-        eval("let a;");
-        console.log();
-    }
-    expect_stdout: SyntaxError("Unexpected identifier")
-    node_version: "<=0.12"
-}

--- a/test/compress/object.js
+++ b/test/compress/object.js
@@ -649,7 +649,6 @@ concise_method_to_prop_arrow: {
         "3",
         "4",
     ]
-    node_version: ">=4"
 }
 
 prop_func_to_async_concise_method: {
@@ -772,7 +771,6 @@ prop_arrow_with_this: {
         "undefined",
         "global",
     ]
-    node_version: ">=4"
 }
 
 prop_arrow_with_nested_this: {
@@ -810,7 +808,6 @@ prop_arrow_with_nested_this: {
         "global",
         "global",
     ]
-    node_version: ">=4"
 }
 
 issue_2554_1: {
@@ -851,7 +848,6 @@ issue_2554_1: {
         console.log(obj.g);
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 issue_2554_2: {
@@ -937,7 +933,6 @@ issue_2554_3: {
         console.log(foo[3]);
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 issue_2554_4: {

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -830,7 +830,6 @@ issue_2208_6: {
         console.log(42);
     }
     expect_stdout: "42"
-    node_version: ">=4"
 }
 
 issue_2208_7: {
@@ -852,7 +851,6 @@ issue_2208_7: {
         console.log(42);
     }
     expect_stdout: "42"
-    node_version: ">=4"
 }
 
 issue_2208_8: {
@@ -910,7 +908,6 @@ issue_2208_9: {
         }());
     }
     expect_stdout: "42"
-    node_version: ">=4"
 }
 
 methods_keep_quoted_true: {
@@ -1238,7 +1235,6 @@ accessor_1: {
         }.a);
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 accessor_2: {
@@ -1305,7 +1301,6 @@ computed_property: {
         "foo",
         "bar"
     ]
-    node_version: ">=4"
 }
 
 new_this: {
@@ -1903,7 +1898,6 @@ issue_2816_ecma6: {
         console.log(o.a, o.b, o.c);
     }
     expect_stdout: "3 2 4"
-    node_version: ">=4"
 }
 
 issue_2893_1: {

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -3158,7 +3158,6 @@ issue_2090_1: {
         }());
     }
     expect_stdout: "1"
-    node_version: ">=4"
 }
 
 issue_2090_2: {
@@ -3186,7 +3185,6 @@ issue_2090_2: {
         }());
     }
     expect_stdout: "1"
-    node_version: ">=4"
 }
 
 for_in_prop: {
@@ -3517,7 +3515,6 @@ array_forof_1: {
         "2",
         "3",
     ]
-    node_version: ">=0.12"
 }
 
 array_forof_2: {
@@ -3540,7 +3537,6 @@ array_forof_2: {
         console.log(a.length);
     }
     expect_stdout: "3"
-    node_version: ">=0.12"
 }
 
 const_expr_1: {
@@ -3915,7 +3911,6 @@ issue_2420_3: {
         "foo 1",
         "true true true",
     ]
-    node_version: ">=4"
 }
 
 issue_2423_1: {
@@ -5266,7 +5261,6 @@ escape_yield: {
         })();
     }
     expect_stdout: "PASS"
-    node_version: ">=4"
 }
 
 escape_await: {

--- a/test/compress/template-string.js
+++ b/test/compress/template-string.js
@@ -461,7 +461,6 @@ simple_string: {
         console.log([ 1 ][0], true, "world");
     }
     expect_stdout: "1 true 'world'"
-    node_version: ">=4"
 }
 
 semicolons: {
@@ -481,7 +480,6 @@ regex_1: {
     }
     expect_exact: 'console.log(`${/a/} ${6/2} ${/b/.test("b")} ${1?/c/:/d/}`);'
     expect_stdout: "/a/ 3 true /c/"
-    node_version: ">=4"
 }
 
 regex_2: {
@@ -496,7 +494,6 @@ regex_2: {
         console.log("/a/ 3 true /c/");
     }
     expect_stdout: "/a/ 3 true /c/"
-    node_version: ">=4"
 }
 
 sequence_1: {
@@ -505,7 +502,6 @@ sequence_1: {
     }
     expect_exact: 'console.log(`${1,2} ${/a/,/b/}`);'
     expect_stdout: "2 /b/"
-    node_version: ">=4"
 }
 
 sequence_2: {
@@ -520,7 +516,6 @@ sequence_2: {
         console.log("2 /b/");
     }
     expect_stdout: "2 /b/"
-    node_version: ">=4"
 }
 
 return_template_string_with_trailing_backslash: {

--- a/test/compress/yield.js
+++ b/test/compress/yield.js
@@ -249,7 +249,6 @@ issue_2832: {
         "second",
         "2",
     ]
-    node_version: ">=4"
 }
 
 issue_t60: {

--- a/test/mocha/release.js
+++ b/test/mocha/release.js
@@ -13,8 +13,6 @@ function run(command, args, done) {
     });
 }
 
-if (semver.satisfies(process.version, "0.12")) return;
-if (semver.satisfies(process.version, "0.10")) return;
 if (semver.satisfies(process.version, "4")) return;
 if (semver.satisfies(process.version, "6")) return;
 

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -1,4 +1,3 @@
-var semver = require("semver");
 var vm = require("vm");
 
 function safe_log(arg, level) {
@@ -74,14 +73,6 @@ exports.run_code = function(code) {
         process.stdout.write = original_write;
     }
 };
-exports.same_stdout = semver.satisfies(process.version, "0.12") ? function(expected, actual) {
-    if (typeof expected != typeof actual) return false;
-    if (typeof expected != "string") {
-        if (expected.name != actual.name) return false;
-        expected = expected.message.slice(expected.message.lastIndexOf("\n") + 1);
-        actual = actual.message.slice(actual.message.lastIndexOf("\n") + 1);
-    }
-    return strip_func_ids(expected) == strip_func_ids(actual);
-} : function(expected, actual) {
+exports.same_stdout = function(expected, actual) {
     return typeof expected == typeof actual && strip_func_ids(expected) == strip_func_ids(actual);
 };


### PR DESCRIPTION
Required to get the tests green in #209.

Alternatively, version 4 could be the minimum version to build terser, but test runs could still execute on older versions of node.js.