### PR TITLE
Fix parsing of template literals with an escape

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -532,7 +532,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
             raw += ch;
             if (ch == "\\") {
                 var tmp = S.pos;
-                var prev_is_tag = previous_token.type === "name" || previous_token.type === "punc" && (previous_token.value === ")" || previous_token.value === "]");
+                var prev_is_tag = previous_token && (previous_token.type === "name" || previous_token.type === "punc" && (previous_token.value === ")" || previous_token.value === "]"));
                 ch = read_escaped_char(true, !prev_is_tag, true);
                 raw += S.text.substr(tmp, S.pos - tmp);
             }

--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -7,7 +7,6 @@ var minify = require("..").minify;
 var known_terser_errors = new RegExp([
   "Cannot negate a statement",
   "Cannot read property 'references' of undefined",
-  "Cannot read property 'type' of null",
   "Cannot read property 'value' of undefined",
   "Octal escape sequences are not allowed in template strings",
   "Parameter .* was used already",

--- a/test/mocha/template-string.js
+++ b/test/mocha/template-string.js
@@ -39,4 +39,9 @@ describe("Template string", function() {
             assert.strictEqual(uglify.parse(code).print_to_string(), "`a\\nb`;");
         });
     });
+    it("Should not throw on extraneous escape (#231)", function() {
+        assert.doesNotThrow(function() {
+            uglify.parse("`\\a`");
+        });
+    });
 });


### PR DESCRIPTION
Example: \`\»\`