### PR TITLE
Add support for sections sourcemaps (IndexedSourceMapConsumer)

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -59,8 +59,8 @@ function SourceMap(options) {
     });
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
 
-    if (orig_map && Array.isArray(options.orig.sources)) {
-        orig_map._sources.toArray().forEach(function(source) {
+    if (orig_map) {
+        orig_map.sources.forEach(function(source) {
             var sourceContent = orig_map.sourceContentFor(source, true);
             if (sourceContent) {
                 generator.setSourceContent(source, sourceContent);

--- a/test/mocha/sourcemaps.js
+++ b/test/mocha/sourcemaps.js
@@ -26,6 +26,22 @@ function get_map() {
     };
 }
 
+function get_sections_map() {
+    return {
+        "version": 3,
+        "file": "bundle-outer.js",
+        "sections": [
+            {
+                "offset": {
+                    "line": 0,
+                    "column": 0
+                },
+                "map": get_map()
+            }
+        ]
+    };
+}
+
 function prepare_map(sourceMap) {
     var code = [
         '"use strict";',
@@ -223,6 +239,11 @@ describe("sourcemaps", function() {
             var orig = get_map();
             var map = prepare_map(orig);
             assert.equal(map.sourceContentFor("index.js"), orig.sourcesContent[0]);
+        });
+        it("Should copy over original sourcesContent for section sourcemaps", function() {
+            var orig = get_sections_map();
+            var map = prepare_map(orig);
+            assert.equal(map.sourceContentFor("index.js"), orig.sections[0].map.sourcesContent[0]);
         });
         it("Should copy sourcesContent if sources are relative", function() {
             var relativeMap = get_map();


### PR DESCRIPTION
Currently, when you specify an original source map prior to compression, the output will only preserve the original sourcesContent if the original source map was a basic one (`BasicSourceMapConsumer`).

If the original source map was an indexed one with sections, such as those potentially output by basic concatenation tooling, the sourcesContent is lost and is always `null` because currently terser is accessing the private `_sources` property and this property is only populated initially for a `BasicSourceMapConsumer` not an `IndexedSourceMapConsumer`.

This PR updates the code to refer to the `sources` public property on the consumer which is implemented for all consumers and, for an indexed source map, returns all the sources from all the sections.

I added a basic test too.

Let me know if anything else needed! Thanks!