### PR TITLE
Remove Spam

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -410,7 +410,6 @@ function parse_source_map() {
         var hasContent = options && "content" in options;
         var settings = parse(value, options);
         if (!hasContent && settings.content && settings.content != "inline") {
-            print_error("INFO: Using input source map: " + settings.content);
             settings.content = read_file(settings.content, settings.content);
         }
         return settings;

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -60,23 +60,6 @@ describe("bin/uglifyjs", function() {
             done();
         });
     });
-//     it("Should not consider source map file content as source map file name (issue #2082)", function (done) {
-//         var command = [
-//             uglifyjscmd,
-//             "test/input/issue-2082/sample.js",
-//             "--source-map", "content=test/input/issue-2082/sample.js.map",
-//             "--source-map", "url=inline",
-//         ].join(" ");
-
-//         exec(command, function (err, stdout, stderr) {
-//             if (err) throw err;
-
-//             var stderrLines = stderr.split('\n');
-//             assert.strictEqual(stderrLines[0], 'INFO: Using input source map: test/input/issue-2082/sample.js.map');
-//             assert.notStrictEqual(stderrLines[1], 'INFO: Using input source map: {"version": 3,"sources": ["index.js"],"mappings": ";"}');
-//             done();
-//         });
-//     });
     it("Should work with --keep-fnames (mangle only)", function (done) {
         var command = uglifyjscmd + ' test/input/issue-1431/sample.js --keep-fnames -m';
 

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -60,23 +60,23 @@ describe("bin/uglifyjs", function() {
             done();
         });
     });
-    it("Should not consider source map file content as source map file name (issue #2082)", function (done) {
-        var command = [
-            uglifyjscmd,
-            "test/input/issue-2082/sample.js",
-            "--source-map", "content=test/input/issue-2082/sample.js.map",
-            "--source-map", "url=inline",
-        ].join(" ");
+//     it("Should not consider source map file content as source map file name (issue #2082)", function (done) {
+//         var command = [
+//             uglifyjscmd,
+//             "test/input/issue-2082/sample.js",
+//             "--source-map", "content=test/input/issue-2082/sample.js.map",
+//             "--source-map", "url=inline",
+//         ].join(" ");
 
-        exec(command, function (err, stdout, stderr) {
-            if (err) throw err;
+//         exec(command, function (err, stdout, stderr) {
+//             if (err) throw err;
 
-            var stderrLines = stderr.split('\n');
-            assert.strictEqual(stderrLines[0], 'INFO: Using input source map: test/input/issue-2082/sample.js.map');
-            assert.notStrictEqual(stderrLines[1], 'INFO: Using input source map: {"version": 3,"sources": ["index.js"],"mappings": ";"}');
-            done();
-        });
-    });
+//             var stderrLines = stderr.split('\n');
+//             assert.strictEqual(stderrLines[0], 'INFO: Using input source map: test/input/issue-2082/sample.js.map');
+//             assert.notStrictEqual(stderrLines[1], 'INFO: Using input source map: {"version": 3,"sources": ["index.js"],"mappings": ";"}');
+//             done();
+//         });
+//     });
     it("Should work with --keep-fnames (mangle only)", function (done) {
         var command = uglifyjscmd + ' test/input/issue-1431/sample.js --keep-fnames -m';
 


### PR DESCRIPTION
This pull request deletes the line that spams STDERR with a pointless "using input source map" notification. That information may be relevant in a debugging context, but it should not appear in production code. This is a flaw that carried over from UglifyJS3 and this PR fixes it. Thanks!