### PR TITLE
Exclude APIs required only for tests from main bundle

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -89,7 +89,7 @@ import {
     noop,
 } from "./utils.js";
 
-(function(undefined) {
+(function() {
 
     function _(node, descend) {
         node.DEFMETHOD("transform", function(tw, in_list) {

--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ export {
 } from "./lib/utils.js";
 export { base54 } from "./lib/scope.js";
 export { Compressor } from "./lib/compress/index.js";
+export { to_ascii } from "./lib/minify.js";
 export { OutputStream } from "./lib/output.js";
 export { parse }  from "./lib/parse.js";
 export {
@@ -31,11 +32,3 @@ export {
 } from "./lib/propmangle.js";
 export { default_options } from "./tools/node";
 import "./lib/mozilla-ast.js";
-
-// TESTS
-export * from "./lib/ast.js";
-export {
-    JS_Parse_Error,
-    tokenizer,
-} from "./lib/parse.js";
-export { to_ascii } from "./lib/minify.js";

--- a/main.tests.js
+++ b/main.tests.js
@@ -1,0 +1,9 @@
+// Core
+export * from "./main";
+
+// TESTS
+export * from "./lib/ast.js";
+export {
+    JS_Parse_Error,
+    tokenizer,
+} from "./lib/parse.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -626,25 +626,13 @@
       "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=",
       "dev": true
     },
-    "cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
-      }
-    },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
+        "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -806,19 +794,6 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "eslint-scope": {
@@ -1221,12 +1196,6 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1610,12 +1579,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1706,12 +1669,6 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1735,17 +1692,6 @@
         "which": "1.2.x"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "which": {
           "version": "1.2.14",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "acorn": "^6.0.4",
-    "cross-env": "^5.2.0",
     "csv": "^5.1.0",
     "escodegen": "^1.11.0",
     "eslint": "^4.19.1",
@@ -46,10 +45,12 @@
     "semver": "~5.6.0"
   },
   "scripts": {
-    "test": "npm run prepare --silent && istanbul instrument dist/bundle.min.js > dist/bundle.instrumented.js && node test/run-tests.js",
+    "test": "npm run build -- --silent --input=main.tests.js && npm run minify && node test/run-tests.js",
     "lint": "eslint lib",
     "lint-fix": "eslint --fix lib",
-    "prepare": "rimraf dist/* && rollup -c && cd dist && cross-env TERSER_NO_BUNDLE=1 ../bin/uglifyjs bundle.js -mc --source-map 'content=bundle.js.map,includeSources=true,url=bundle.min.js.map' -o bundle.min.js",
+    "build": "rimraf dist/* && rollup -c",
+    "minify": "cd dist && node ../bin/uglifyjsnobundle bundle.js -mc --source-map content=bundle.js.map,includeSources=true -o bundle.min.js",
+    "prepare": "npm run build && npm run minify",
     "postversion": "echo 'Remember to update the changelog!'"
   },
   "keywords": [


### PR DESCRIPTION
bundle.js before: 781kb, after: 776kb

@fabiosantoscode, @nifgraup could you take a look? Actually I'm not sure is it minor or major change according to semver. If this were part of the public APIs, then it should be part of the next major update otherwise it looks like as minor.