### PR TITLE
Replace Dictionary with ES2015 Map

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -253,6 +253,7 @@ function run() {
             result.ast.figure_out_scope({});
         }
         print(JSON.stringify(result.ast, function(key, value) {
+            if (value instanceof Map) return;
             if (value) switch (key) {
               case "thedef":
                 return symdef(value);
@@ -265,7 +266,6 @@ function run() {
             }
             if (skip_key(key)) return;
             if (value instanceof UglifyJS.AST_Token) return;
-            if (value instanceof UglifyJS.Dictionary) return;
             if (value instanceof UglifyJS.AST_Node) {
                 var result = {
                     _class: "AST_" + value.TYPE

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -253,7 +253,6 @@ function run() {
             result.ast.figure_out_scope({});
         }
         print(JSON.stringify(result.ast, function(key, value) {
-            if (value instanceof Map) return;
             if (value) switch (key) {
               case "thedef":
                 return symdef(value);
@@ -262,10 +261,11 @@ function run() {
               case "variables":
               case "functions":
               case "globals":
-                return value.size() ? value.map(symdef) : undefined;
+                return value.size ? collect_from_map(value, symdef) : undefined;
             }
             if (skip_key(key)) return;
             if (value instanceof UglifyJS.AST_Token) return;
+            if (value instanceof Map) return;
             if (value instanceof UglifyJS.AST_Node) {
                 var result = {
                     _class: "AST_" + value.TYPE
@@ -424,6 +424,14 @@ function symdef(def) {
     var ret = (1e6 + def.id) + " " + def.name;
     if (def.mangled_name) ret += " " + def.mangled_name;
     return ret;
+}
+
+function collect_from_map(map, callback) {
+    var result = [];
+    map.forEach(function (def) {
+        result.push(callback(def));
+    });
+    return result;
 }
 
 function format_object(obj) {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -324,8 +324,8 @@ var AST_With = DEFNODE("With", "expression", {
 var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent_scope enclosed cname", {
     $documentation: "Base class for all statements introducing a lexical scope",
     $propdoc: {
-        variables: "[Object/S] a map of name -> SymbolDef for all variables/functions defined in this scope",
-        functions: "[Object/S] like `variables`, but only lists function declarations",
+        variables: "[Map/S] a map of name -> SymbolDef for all variables/functions defined in this scope",
+        functions: "[Map/S] like `variables`, but only lists function declarations",
         uses_with: "[boolean/S] tells whether this scope uses the `with` statement",
         uses_eval: "[boolean/S] tells whether this scope contains a direct call to the global `eval`",
         parent_scope: "[AST_Scope?/S] link to the parent scope",
@@ -341,8 +341,8 @@ var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent
     },
     clone: function(deep) {
         var node = this._clone(deep);
-        if (this.variables) node.variables = this.variables.clone();
-        if (this.functions) node.functions = this.functions.clone();
+        if (this.variables) node.variables = new Map(this.variables);
+        if (this.functions) node.functions = new Map(this.functions);
         if (this.enclosed) node.enclosed = this.enclosed.slice();
         return node;
     },

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -354,7 +354,7 @@ var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent
 var AST_Toplevel = DEFNODE("Toplevel", "globals", {
     $documentation: "The toplevel scope",
     $propdoc: {
-        globals: "[Object/S] a map of name -> SymbolDef for all undeclared names",
+        globals: "[Map/S] a map of name -> SymbolDef for all undeclared names",
     },
     wrap_commonjs: function(name) {
         var body = this.body;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -558,7 +558,7 @@ merge(Compressor.prototype, {
         }
 
         function reset_variables(tw, compressor, node) {
-            node.variables.each(function(def) {
+            node.variables.forEach(function(def) {
                 reset_def(compressor, def);
                 if (def.fixed === null) {
                     def.safe_ids = tw.safe_ids;
@@ -571,7 +571,7 @@ merge(Compressor.prototype, {
         }
 
         function reset_block_variables(compressor, node) {
-            if (node.block_scope) node.block_scope.variables.each(function(def) {
+            if (node.block_scope) node.block_scope.variables.forEach(function(def) {
                 reset_def(compressor, def);
             });
         }
@@ -3501,7 +3501,7 @@ merge(Compressor.prototype, {
         var in_use_ids = Object.create(null); // avoid expensive linear scans of in_use
         var fixed_ids = Object.create(null);
         if (self instanceof AST_Toplevel && compressor.top_retain) {
-            self.variables.each(function(def) {
+            self.variables.forEach(function(def) {
                 if (compressor.top_retain(def) && !(def.id in in_use_ids)) {
                     in_use_ids[def.id] = true;
                     in_use.push(def);
@@ -3994,7 +3994,7 @@ merge(Compressor.prototype, {
             this.enclosed.forEach(function(def) {
                 var_names[def.name] = true;
             });
-            this.variables.each(function(def, name) {
+            this.variables.forEach(function(def, name) {
                 var_names[name] = true;
             });
         }
@@ -5205,7 +5205,7 @@ merge(Compressor.prototype, {
                     if (scope.block_scope) {
                         // TODO this is sometimes undefined during compression.
                         // But it should always have a value!
-                        scope.block_scope.variables.each(function (variable) {
+                        scope.block_scope.variables.forEach(function (variable) {
                             block_scoped[variable.name] = true;
                         });
                     }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1498,7 +1498,7 @@ merge(Compressor.prototype, {
                     if (fn_strict && !member(fn_strict, fn.body)) fn_strict = false;
                     var len = fn.argnames.length;
                     args = iife.args.slice(len);
-                    var names = Object.create(null);
+                    var names = new Set();
                     for (var i = len; --i >= 0;) {
                         var sym = fn.argnames[i];
                         var arg = iife.args[i];
@@ -1506,8 +1506,8 @@ merge(Compressor.prototype, {
                             name: sym,
                             value: arg
                         }));
-                        if (sym.name in names) continue;
-                        names[sym.name] = true;
+                        if (names.has(sym.name)) continue;
+                        names.add(sym.name);
                         if (sym instanceof AST_Expansion) {
                             var elements = iife.args.slice(i);
                             if (all(elements, function(arg) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3497,14 +3497,12 @@ merge(Compressor.prototype, {
             }
             if (node instanceof AST_Unary && node.write_only) return node.expression;
         };
-        var in_use = [];
-        var in_use_ids = new Set(); // avoid expensive linear scans of in_use
+        var in_use_ids = new Map();
         var fixed_ids = new Map();
         if (self instanceof AST_Toplevel && compressor.top_retain) {
             self.variables.forEach(function(def) {
                 if (compressor.top_retain(def) && !in_use_ids.has(def.id)) {
-                    in_use_ids.add(def.id);
-                    in_use.push(def);
+                    in_use_ids.set(def.id, def);
                 }
             });
         }
@@ -3520,8 +3518,7 @@ merge(Compressor.prototype, {
                     if (!(argname instanceof AST_SymbolDeclaration)) return;
                     var def = argname.definition();
                     if (!in_use_ids.has(def.id)) {
-                        in_use_ids.add(def.id);
-                        in_use.push(def);
+                        in_use_ids.set(def.id, def);
                     }
                 });
             }
@@ -3531,8 +3528,7 @@ merge(Compressor.prototype, {
                 var in_export = tw.parent() instanceof AST_Export;
                 if (in_export || !drop_funcs && scope === self) {
                     if (node_def.global && !in_use_ids.has(node_def.id)) {
-                        in_use_ids.add(node_def.id);
-                        in_use.push(node_def);
+                        in_use_ids.set(node_def.id, node_def);
                     }
                 }
                 map_add(initializations, node_def.id, node);
@@ -3552,8 +3548,7 @@ merge(Compressor.prototype, {
                             if (node instanceof AST_SymbolDeclaration) {
                                 var def = node.definition();
                                 if ((in_export || def.global) && !in_use_ids.has(def.id)) {
-                                    in_use_ids.add(def.id);
-                                    in_use.push(def);
+                                    in_use_ids.set(def.id, def);
                                 }
                             }
                         }));
@@ -3588,12 +3583,12 @@ merge(Compressor.prototype, {
         // initialization code to figure out if it uses other
         // symbols (that may not be in_use).
         tw = new TreeWalker(scan_ref_scoped);
-        for (var i = 0; i < in_use.length; i++) {
-            var init = initializations.get(in_use[i].id);
+        in_use_ids.forEach(function (def) {
+            var init = initializations.get(def.id);
             if (init) init.forEach(function(init) {
                 init.walk(tw);
             });
-        }
+        });
         // pass 3: we should drop declarations not in_use
         var tt = new TreeTransformer(
             function before(node, descend, in_list) {
@@ -3831,11 +3826,9 @@ merge(Compressor.prototype, {
             if (node instanceof AST_SymbolRef) {
                 node_def = node.definition();
                 if (!in_use_ids.has(node_def.id)) {
-                    in_use_ids.add(node_def.id);
-                    in_use.push(node_def);
+                    in_use_ids.set(node_def.id, node_def);
                     if (node_def = node_def.redefined()) {
-                        in_use_ids.add(node_def.id);
-                        in_use.push(node_def);
+                        in_use_ids.set(node_def.id, node_def);
                     }
                 }
                 return true;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3990,12 +3990,12 @@ merge(Compressor.prototype, {
         var var_names = this._var_names;
         if (!var_names) {
             const isParentScopeAvailable = this.parent_scope && !this.parent_scope instanceof AST_Toplevel;
-            this._var_names = var_names = isParentScopeAvailable ? varNames.call(this.parent_scope) : Object.create(null);
+            this._var_names = var_names = isParentScopeAvailable ? varNames.call(this.parent_scope) : new Set();
             this.enclosed.forEach(function(def) {
-                var_names[def.name] = true;
+                var_names.add(def.name);
             });
             this.variables.forEach(function(def, name) {
-                var_names[name] = true;
+                var_names.add(name);
             });
         }
         return var_names;
@@ -4005,8 +4005,8 @@ merge(Compressor.prototype, {
         var var_names = this.var_names();
         prefix = prefix.replace(/(?:^[^a-z_$]|[^a-z0-9_$])/ig, "_");
         var name = prefix;
-        for (var i = 0; var_names[name]; i++) name = prefix + "$" + i;
-        var_names[name] = true;
+        for (var i = 0; var_names.has(name); i++) name = prefix + "$" + i;
+        var_names.add(name);
         return name;
     });
 
@@ -5169,7 +5169,7 @@ merge(Compressor.prototype, {
                 if (!safe_to_inject
                     || block_scoped[arg.name]
                     || identifier_atom(arg.name)
-                    || scope.var_names()[arg.name]) {
+                    || scope.var_names().has(arg.name)) {
                     return false;
                 }
                 if (in_loop) in_loop.push(arg.definition());
@@ -5188,7 +5188,7 @@ merge(Compressor.prototype, {
                     if (name instanceof AST_Destructuring
                         || block_scoped[name.name]
                         || identifier_atom(name.name)
-                        || scope.var_names()[name.name]) {
+                        || scope.var_names().has(name.name)) {
                         return false;
                     }
                     if (in_loop) in_loop.push(name.definition());
@@ -5231,8 +5231,8 @@ merge(Compressor.prototype, {
             var def = name.definition();
             scope.variables.set(name.name, def);
             scope.enclosed.push(def);
-            if (!scope.var_names()[name.name]) {
-                scope.var_names()[name.name] = true;
+            if (!scope.var_names().has(name.name)) {
+                scope.var_names().add(name.name);
                 decls.push(make_node(AST_VarDef, name, {
                     name: name,
                     value: null
@@ -5255,7 +5255,7 @@ merge(Compressor.prototype, {
             for (i = len; --i >= 0;) {
                 var name = fn.argnames[i];
                 var value = self.args[i];
-                if (name.__unused || !name.name || scope.var_names()[name.name]) {
+                if (name.__unused || !name.name || scope.var_names().has(name.name)) {
                     if (value) expressions.push(value);
                 } else {
                     var symbol = make_node(AST_SymbolVar, name, name);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -46,12 +46,12 @@
 import {
     all,
     defaults,
-    Dictionary,
     find_if,
     first_in_statement,
     HOP,
     keep_name,
     makePredicate,
+    map_add,
     MAP,
     member,
     merge,
@@ -3508,8 +3508,8 @@ merge(Compressor.prototype, {
                 }
             });
         }
-        var var_defs_by_id = new Dictionary();
-        var initializations = new Dictionary();
+        var var_defs_by_id = new Map();
+        var initializations = new Map();
         var destructuring_value = null;
         // pass 1: find out which symbols are directly used in
         // this scope (not in nested scopes).
@@ -3535,17 +3535,17 @@ merge(Compressor.prototype, {
                         in_use.push(node_def);
                     }
                 }
-                initializations.add(node_def.id, node);
+                map_add(initializations, node_def.id, node);
                 return true; // don't go in nested scopes
             }
             if (node instanceof AST_SymbolFunarg && scope === self) {
-                var_defs_by_id.add(node.definition().id, node);
+                map_add(var_defs_by_id, node.definition().id, node);
             }
             if (node instanceof AST_Definitions && scope === self) {
                 var in_export = tw.parent() instanceof AST_Export;
                 node.definitions.forEach(function(def) {
                     if (def.name instanceof AST_SymbolVar) {
-                        var_defs_by_id.add(def.name.definition().id, def);
+                        map_add(var_defs_by_id, def.name.definition().id, def);
                     }
                     if (in_export || !drop_vars) {
                         def.name.walk(new TreeWalker(function(node) {
@@ -3566,7 +3566,7 @@ merge(Compressor.prototype, {
                             destructuring_value = destructuring_cache;
                         } else {
                             var node_def = def.name.definition();
-                            initializations.add(node_def.id, def.value);
+                            map_add(initializations, node_def.id, def.value);
                             if (!node_def.chained && def.name.fixed_value() === def.value) {
                                 fixed_ids[node_def.id] = def;
                             }
@@ -3579,7 +3579,7 @@ merge(Compressor.prototype, {
                 return true;
             }
             if (node.destructuring && destructuring_value) {
-                initializations.add(node.name, destructuring_value);
+                map_add(initializations, node.name, destructuring_value);
             }
             return scan_ref_scoped(node, descend);
         });
@@ -3862,7 +3862,7 @@ merge(Compressor.prototype, {
         if (hoist_funs || hoist_vars) {
             var dirs = [];
             var hoisted = [];
-            var vars = new Dictionary(), vars_found = 0, var_decl = 0;
+            var vars = new Map(), vars_found = 0, var_decl = 0;
             // let's count var_decl first, we seem to waste a lot of
             // space if we hoist `var` when there's only one.
             self.walk(new TreeWalker(function(node) {
@@ -3919,11 +3919,11 @@ merge(Compressor.prototype, {
             if (vars_found > 0) {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];
-                vars.each(function(def, name) {
+                vars.forEach(function(def, name) {
                     if (self instanceof AST_Lambda
                         && find_if(function(x) { return x.name == def.name.name; },
                                    self.args_as_names())) {
-                        vars.del(name);
+                        vars.delete(name);
                     } else {
                         def = def.clone();
                         def.value = null;
@@ -4029,7 +4029,7 @@ merge(Compressor.prototype, {
                     && (value = sym.fixed_value()) === node.value
                     && value instanceof AST_Object) {
                     descend(node, this);
-                    var defs = new Dictionary();
+                    var defs = new Map();
                     var assignments = [];
                     value.properties.forEach(function(prop) {
                         assignments.push(make_node(AST_VarDef, node, {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6547,17 +6547,17 @@ merge(Compressor.prototype, {
             && !(fn instanceof AST_Arrow)
             && prop instanceof AST_Number) {
             var index = prop.getValue();
-            var params = Object.create(null);
+            var params = new Set();
             var argnames = fn.argnames;
             for (var n = 0; n < argnames.length; n++) {
                 if (!(argnames[n] instanceof AST_SymbolFunarg)) {
                     break OPT_ARGUMENTS; // destructuring parameter - bail
                 }
                 var param = argnames[n].name;
-                if (param in params) {
+                if (params.has(param)) {
                     break OPT_ARGUMENTS; // duplicate parameter - bail
                 }
-                params[param] = true;
+                params.add(param);
             }
             var argname = fn.argnames[index];
             if (argname && compressor.has_directive("use strict")) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3498,12 +3498,12 @@ merge(Compressor.prototype, {
             if (node instanceof AST_Unary && node.write_only) return node.expression;
         };
         var in_use = [];
-        var in_use_ids = Object.create(null); // avoid expensive linear scans of in_use
-        var fixed_ids = Object.create(null);
+        var in_use_ids = new Set(); // avoid expensive linear scans of in_use
+        var fixed_ids = new Map();
         if (self instanceof AST_Toplevel && compressor.top_retain) {
             self.variables.forEach(function(def) {
-                if (compressor.top_retain(def) && !(def.id in in_use_ids)) {
-                    in_use_ids[def.id] = true;
+                if (compressor.top_retain(def) && !in_use_ids.has(def.id)) {
+                    in_use_ids.add(def.id);
                     in_use.push(def);
                 }
             });
@@ -3519,8 +3519,8 @@ merge(Compressor.prototype, {
                 node.argnames.forEach(function(argname) {
                     if (!(argname instanceof AST_SymbolDeclaration)) return;
                     var def = argname.definition();
-                    if (!(def.id in in_use_ids)) {
-                        in_use_ids[def.id] = true;
+                    if (!in_use_ids.has(def.id)) {
+                        in_use_ids.add(def.id);
                         in_use.push(def);
                     }
                 });
@@ -3530,8 +3530,8 @@ merge(Compressor.prototype, {
                 var node_def = node.name.definition();
                 var in_export = tw.parent() instanceof AST_Export;
                 if (in_export || !drop_funcs && scope === self) {
-                    if (node_def.global && !(node_def.id in in_use_ids)) {
-                        in_use_ids[node_def.id] = true;
+                    if (node_def.global && !in_use_ids.has(node_def.id)) {
+                        in_use_ids.add(node_def.id);
                         in_use.push(node_def);
                     }
                 }
@@ -3551,8 +3551,8 @@ merge(Compressor.prototype, {
                         def.name.walk(new TreeWalker(function(node) {
                             if (node instanceof AST_SymbolDeclaration) {
                                 var def = node.definition();
-                                if ((in_export || def.global) && !(def.id in in_use_ids)) {
-                                    in_use_ids[def.id] = true;
+                                if ((in_export || def.global) && !in_use_ids.has(def.id)) {
+                                    in_use_ids.add(def.id);
                                     in_use.push(def);
                                 }
                             }
@@ -3568,7 +3568,7 @@ merge(Compressor.prototype, {
                             var node_def = def.name.definition();
                             map_add(initializations, node_def.id, def.value);
                             if (!node_def.chained && def.name.fixed_value() === def.value) {
-                                fixed_ids[node_def.id] = def;
+                                fixed_ids.set(node_def.id, def);
                             }
                         }
                         if (def.value.has_side_effects(compressor)) {
@@ -3602,9 +3602,9 @@ merge(Compressor.prototype, {
                     var sym = assign_as_unused(node);
                     if (sym instanceof AST_SymbolRef) {
                         var def = sym.definition();
-                        var in_use = def.id in in_use_ids;
+                        var in_use = in_use_ids.has(def.id);
                         if (node instanceof AST_Assign) {
-                            if (!in_use || def.id in fixed_ids && fixed_ids[def.id] !== node) {
+                            if (!in_use || fixed_ids.has(def.id) && fixed_ids.get(def.id) !== node) {
                                 return maintain_this_binding(parent, node, node.right.transform(tt));
                             }
                         } else if (!in_use) return make_node(AST_Number, node, {
@@ -3622,7 +3622,7 @@ merge(Compressor.prototype, {
                     // any declarations with same name will overshadow
                     // name of this anonymous function and can therefore
                     // never be used anywhere
-                    if (!(def.id in in_use_ids) || def.orig.length > 1) node.name = null;
+                    if (!in_use_ids.has(def.id) || def.orig.length > 1) node.name = null;
                 }
                 if (node instanceof AST_Lambda && !(node instanceof AST_Accessor)) {
                     var trim = !compressor.option("keep_fargs");
@@ -3639,7 +3639,7 @@ merge(Compressor.prototype, {
                         // them would stop that TypeError which would happen
                         // if someone called it with an incorrectly formatted
                         // parameter.
-                        if (!(sym instanceof AST_Destructuring) && !(sym.definition().id in in_use_ids)) {
+                        if (!(sym instanceof AST_Destructuring) && !in_use_ids.has(sym.definition().id)) {
                             sym.__unused = true;
                             if (trim) {
                                 a.pop();
@@ -3652,7 +3652,7 @@ merge(Compressor.prototype, {
                 }
                 if ((node instanceof AST_Defun || node instanceof AST_DefClass) && node !== self) {
                     var def = node.name.definition();
-                    var keep = (def.id in in_use_ids) || !drop_funcs && def.global;
+                    var keep = in_use_ids.has(def.id) || !drop_funcs && def.global;
                     if (!keep) {
                         compressor[node.name.unreferenced() ? "warn" : "info"]("Dropping unused function {name} [{file}:{line},{col}]", template(node.name));
                         def.eliminated++;
@@ -3679,8 +3679,8 @@ merge(Compressor.prototype, {
                                 && (def.name.names.length
                                     || def.name.is_array
                                     || compressor.option("pure_getters") != true)
-                            || sym.id in in_use_ids) {
-                            if (def.value && sym.id in fixed_ids && fixed_ids[sym.id] !== def) {
+                            || in_use_ids.has(sym.id)) {
+                            if (def.value && fixed_ids.has(sym.id) && fixed_ids.get(sym.id) !== def) {
                                 def.value = def.value.drop_side_effect_free(compressor);
                             }
                             if (def.name instanceof AST_SymbolVar) {
@@ -3695,8 +3695,8 @@ merge(Compressor.prototype, {
                                             left: ref,
                                             right: def.value
                                         });
-                                        if (fixed_ids[sym.id] === def) {
-                                            fixed_ids[sym.id] = assign;
+                                        if (fixed_ids.get(sym.id) === def) {
+                                            fixed_ids.set(sym.id, assign);
                                         }
                                         side_effects.push(assign.transform(tt));
                                     }
@@ -3823,18 +3823,18 @@ merge(Compressor.prototype, {
                 if (node instanceof AST_Assign) {
                     node.right.walk(tw);
                     if (!node_def.chained && node.left.fixed_value() === node.right) {
-                        fixed_ids[node_def.id] = node;
+                        fixed_ids.set(node_def.id, node);
                     }
                 }
                 return true;
             }
             if (node instanceof AST_SymbolRef) {
                 node_def = node.definition();
-                if (!(node_def.id in in_use_ids)) {
-                    in_use_ids[node_def.id] = true;
+                if (!in_use_ids.has(node_def.id)) {
+                    in_use_ids.add(node_def.id);
                     in_use.push(node_def);
                     if (node_def = node_def.redefined()) {
-                        in_use_ids[node_def.id] = true;
+                        in_use_ids.add(node_def.id);
                         in_use.push(node_def);
                     }
                 }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4044,7 +4044,7 @@ merge(Compressor.prototype, {
             if (node instanceof AST_PropAccess && node.expression instanceof AST_SymbolRef) {
                 var defs = defs_by_id[node.expression.definition().id];
                 if (defs) {
-                    var def = defs.get(get_value(node.property));
+                    var def = defs.get(String(get_value(node.property)));
                     var sym = make_node(AST_SymbolRef, node, {
                         name: def.name,
                         scope: node.expression.scope,
@@ -4061,7 +4061,7 @@ merge(Compressor.prototype, {
                     scope: self
                 });
                 var def = self.def_variable(new_var);
-                defs.set(key, def);
+                defs.set(String(key), def);
                 self.enclosed.push(def);
                 return new_var;
             }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -906,7 +906,7 @@ merge(Compressor.prototype, {
             mark_escaped(tw, d, this.scope, this, value, 0, 1);
         });
         def_reduce_vars(AST_Toplevel, function(tw, descend, compressor) {
-            this.globals.each(function(def) {
+            this.globals.forEach(function(def) {
                 reset_def(compressor, def);
             });
             reset_variables(tw, compressor, this);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5167,7 +5167,7 @@ merge(Compressor.prototype, {
                 }
                 if (arg.__unused) continue;
                 if (!safe_to_inject
-                    || block_scoped[arg.name]
+                    || block_scoped.has(arg.name)
                     || identifier_atom(arg.name)
                     || scope.var_names().has(arg.name)) {
                     return false;
@@ -5186,7 +5186,7 @@ merge(Compressor.prototype, {
                 for (var j = stat.definitions.length; --j >= 0;) {
                     var name = stat.definitions[j].name;
                     if (name instanceof AST_Destructuring
-                        || block_scoped[name.name]
+                        || block_scoped.has(name.name)
                         || identifier_atom(name.name)
                         || scope.var_names().has(name.name)) {
                         return false;
@@ -5198,7 +5198,7 @@ merge(Compressor.prototype, {
         }
 
         function can_inject_symbols() {
-            var block_scoped = Object.create(null);
+            var block_scoped = new Set();
             do {
                 scope = compressor.parent(++level);
                 if (scope.is_block_scope() && !(compressor.parent(level - 1) instanceof AST_Scope)) {
@@ -5206,13 +5206,13 @@ merge(Compressor.prototype, {
                         // TODO this is sometimes undefined during compression.
                         // But it should always have a value!
                         scope.block_scope.variables.forEach(function (variable) {
-                            block_scoped[variable.name] = true;
+                            block_scoped.add(variable.name);
                         });
                     }
                 }
                 if (scope instanceof AST_Catch) {
                     if (scope.argname) {
-                        block_scoped[scope.argname.name] = true;
+                        block_scoped.add(scope.argname.name);
                     }
                 } else if (scope instanceof AST_IterationStatement) {
                     in_loop = [];

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1344,11 +1344,11 @@ merge(Compressor.prototype, {
                     || node instanceof AST_PropAccess
                         && (side_effects || node.expression.may_throw_on_access(compressor))
                     || node instanceof AST_SymbolRef
-                        && (lvalues[node.name] || side_effects && may_modify(node))
+                        && (lvalues.get(node.name) || side_effects && may_modify(node))
                     || node instanceof AST_VarDef && node.value
-                        && (node.name.name in lvalues || side_effects && may_modify(node.name))
+                        && (lvalues.has(node.name.name) || side_effects && may_modify(node.name))
                     || (sym = is_lhs(node.left, node))
-                        && (sym instanceof AST_PropAccess || sym.name in lvalues)
+                        && (sym instanceof AST_PropAccess || lvalues.has(sym.name))
                     || may_throw
                         && (in_try ? node.has_side_effects(compressor) : side_effects_external(node))) {
                     stop_after = node;
@@ -1403,7 +1403,7 @@ merge(Compressor.prototype, {
                     // Locate symbols which may execute code outside of scanning range
                     var lvalues = get_lvalues(candidate);
                     var lhs_local = is_lhs_local(lhs);
-                    if (lhs instanceof AST_SymbolRef) lvalues[lhs.name] = false;
+                    if (lhs instanceof AST_SymbolRef) lvalues.set(lhs.name, false);
                     var side_effects = value_has_side_effects(candidate);
                     var replace_all = replace_all_symbols();
                     var may_throw = candidate.may_throw(compressor);
@@ -1616,7 +1616,7 @@ merge(Compressor.prototype, {
                 if (parent instanceof AST_Assign) {
                     if (write_only
                         && !(parent.left instanceof AST_PropAccess
-                            || parent.left.name in lvalues)) {
+                            || lvalues.has(parent.left.name))) {
                         return find_stop(parent, level + 1, write_only);
                     }
                     return node;
@@ -1690,13 +1690,13 @@ merge(Compressor.prototype, {
             }
 
             function get_lvalues(expr) {
-                var lvalues = Object.create(null);
+                var lvalues = new Map();
                 if (expr instanceof AST_Unary) return lvalues;
                 var tw = new TreeWalker(function(node, descend) {
                     var sym = node;
                     while (sym instanceof AST_PropAccess) sym = sym.expression;
                     if (sym instanceof AST_SymbolRef || sym instanceof AST_This) {
-                        lvalues[sym.name] = lvalues[sym.name] || is_modified(compressor, tw, node, node, 0);
+                        lvalues.set(sym.name, lvalues.get(sym.name) || is_modified(compressor, tw, node, node, 0));
                     }
                 });
                 get_rvalue(expr).walk(tw);
@@ -1741,7 +1741,7 @@ merge(Compressor.prototype, {
                 return lhs instanceof AST_SymbolRef
                     && lhs.definition().scope === scope
                     && !(in_loop
-                        && (lhs.name in lvalues
+                        && (lvalues.has(lhs.name)
                             || candidate instanceof AST_Unary
                             || candidate instanceof AST_Assign && candidate.operator != "="));
             }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4014,7 +4014,7 @@ merge(Compressor.prototype, {
         var self = this;
         if (!compressor.option("hoist_props") || compressor.has_directive("use asm")) return self;
         var top_retain = self instanceof AST_Toplevel && compressor.top_retain || return_false;
-        var defs_by_id = Object.create(null);
+        var defs_by_id = new Map();
         var tt = new TreeTransformer(function(node, descend) {
             if (node instanceof AST_Definitions && tt.parent() instanceof AST_Export) return node;
             if (node instanceof AST_VarDef) {
@@ -4037,12 +4037,12 @@ merge(Compressor.prototype, {
                             value: prop.value
                         }));
                     });
-                    defs_by_id[def.id] = defs;
+                    defs_by_id.set(def.id, defs);
                     return MAP.splice(assignments);
                 }
             }
             if (node instanceof AST_PropAccess && node.expression instanceof AST_SymbolRef) {
-                var defs = defs_by_id[node.expression.definition().id];
+                var defs = defs_by_id.get(node.expression.definition().id);
                 if (defs) {
                     var def = defs.get(String(get_value(node.property)));
                     var sym = make_node(AST_SymbolRef, node, {

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -3,7 +3,8 @@
 
 import {
     defaults,
-    Dictionary,
+    map_from_object,
+    map_to_object,
     HOP,
 } from "./utils.js";
 import {
@@ -50,15 +51,15 @@ function set_shorthand(name, options, keys) {
 function init_cache(cache) {
     if (!cache) return;
     if (!("props" in cache)) {
-        cache.props = new Dictionary();
-    } else if (!(cache.props instanceof Dictionary)) {
-        cache.props = Dictionary.fromObject(cache.props);
+        cache.props = new Map();
+    } else if (!(cache.props instanceof Map)) {
+        cache.props = map_from_object(cache.props);
     }
 }
 
 function to_json(cache) {
     return {
-        props: cache.props.toObject()
+        props: map_to_object(cache.props)
     };
 }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1490,20 +1490,20 @@ function parse($TEXT, options) {
     };
 
     function track_used_binding_identifiers(is_parameter, strict) {
-        var parameters = {};
+        var parameters = new Set();
         var duplicate = false;
         var default_assignment = false;
         var spread = false;
         var strict_mode = !!strict;
         var tracker = {
             add_parameter: function(token) {
-                if (parameters["$" + token.value] !== undefined) {
+                if (parameters.has(token.value)) {
                     if (duplicate === false) {
                         duplicate = token;
                     }
                     tracker.check_strict();
                 } else {
-                    parameters["$" + token.value] = true;
+                    parameters.add(token.value);
                     if (is_parameter) {
                         switch (token.value) {
                           case "arguments":

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -46,7 +46,6 @@
 
 import {
     defaults,
-    Dictionary,
     push_uniq,
 } from "./utils";
 import { base54 } from "./scope";
@@ -157,11 +156,11 @@ function mangle_properties(ast, options) {
     var cache;
     if (options.cache) {
         cache = options.cache.props;
-        cache.each(function(mangled_name) {
+        cache.forEach(function(mangled_name) {
             reserved.add(mangled_name);
         });
     } else {
-        cache = new Dictionary();
+        cache = new Map();
     }
 
     var regex = options.regex;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -652,7 +652,7 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
 
 AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
     var cache = options.cache && options.cache.props;
-    var avoid = Object.create(null);
+    var avoid = new Set();
     options.reserved.forEach(to_avoid);
     this.globals.forEach(add_def);
     this.walk(new TreeWalker(function(node) {
@@ -662,7 +662,7 @@ AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
     return avoid;
 
     function to_avoid(name) {
-        avoid[name] = true;
+        avoid.add(name);
     }
 
     function add_def(def) {
@@ -689,7 +689,7 @@ AST_Toplevel.DEFMETHOD("expand_names", function(options) {
         var name;
         do {
             name = base54(cname++);
-        } while (avoid[name] || !is_identifier(name));
+        } while (avoid.has(name) || !is_identifier(name));
         return name;
     }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -331,7 +331,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options) {
     self.walk(tw);
 
     // pass 2: find back references and eval
-    self.globals = new Dictionary();
+    self.globals = new Map();
     var tw = new TreeWalker(function(node, descend) {
         if (node instanceof AST_LoopControl && node.label) {
             node.label.thedef.references.push(node);
@@ -604,7 +604,7 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
 
     var mangled_names = this.mangled_names = new Set();
     if (options.cache) {
-        this.globals.each(collect);
+        this.globals.forEach(collect);
         if (options.cache.props) {
             options.cache.props.forEach(function(mangled_name) {
                 mangled_names.add(mangled_name);
@@ -655,7 +655,7 @@ AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
     var cache = options.cache && options.cache.props;
     var avoid = Object.create(null);
     options.reserved.forEach(to_avoid);
-    this.globals.each(add_def);
+    this.globals.forEach(add_def);
     this.walk(new TreeWalker(function(node) {
         if (node instanceof AST_Scope) node.variables.each(add_def);
         if (node instanceof AST_SymbolCatch) add_def(node.definition());
@@ -680,7 +680,7 @@ AST_Toplevel.DEFMETHOD("expand_names", function(options) {
     options = this._default_mangler_options(options);
     var avoid = this.find_colliding_names(options);
     var cname = 0;
-    this.globals.each(rename);
+    this.globals.forEach(rename);
     this.walk(new TreeWalker(function(node) {
         if (node instanceof AST_Scope) node.variables.each(rename);
         if (node instanceof AST_SymbolCatch) rename(node.definition());

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -176,7 +176,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options) {
     // pass 1: setup scope chaining and handle definitions
     var self = this;
     var scope = self.parent_scope = null;
-    var labels = new Dictionary();
+    var labels = new Map();
     var defun = null;
     var in_destructuring = null;
     var for_scopes = [];
@@ -211,7 +211,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options) {
             var save_defun = defun;
             var save_labels = labels;
             defun = scope = node;
-            labels = new Dictionary();
+            labels = new Map();
             descend();
             scope = save_scope;
             defun = save_defun;
@@ -225,7 +225,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options) {
             }
             labels.set(l.name, l);
             descend();
-            labels.del(l.name);
+            labels.delete(l.name);
             return true;        // no descend again
         }
         if (node instanceof AST_With) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -751,21 +751,21 @@ var base54 = (function() {
     var digits = "0123456789".split("");
     var chars, frequency;
     function reset() {
-        frequency = Object.create(null);
+        frequency = new Map();
         leading.forEach(function(ch) {
-            frequency[ch] = 0;
+            frequency.set(ch, 0);
         });
         digits.forEach(function(ch) {
-            frequency[ch] = 0;
+            frequency.set(ch, 0);
         });
     }
     base54.consider = function(str, delta) {
         for (var i = str.length; --i >= 0;) {
-            frequency[str[i]] += delta;
+            frequency.set(str[i], frequency.get(str[i]) + delta);
         }
     };
     function compare(a, b) {
-        return frequency[b] - frequency[a];
+        return frequency.get(b) - frequency.get(a);
     }
     base54.sort = function() {
         chars = mergeSort(leading, compare).concat(mergeSort(digits, compare));

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -606,7 +606,7 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
     if (options.cache) {
         this.globals.each(collect);
         if (options.cache.props) {
-            options.cache.props.each(function(mangled_name) {
+            options.cache.props.forEach(function(mangled_name) {
                 mangled_names.add(mangled_name);
             });
         }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -46,7 +46,6 @@
 import {
     all,
     defaults,
-    Dictionary,
     keep_name,
     member,
     mergeSort,
@@ -399,7 +398,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options) {
     if (options.safari10) {
         for (var i = 0; i < for_scopes.length; i++) {
             var scope = for_scopes[i];
-            scope.parent_scope.variables.each(function(def) {
+            scope.parent_scope.variables.forEach(function(def) {
                 push_uniq(scope.enclosed, def);
             });
         }
@@ -420,8 +419,8 @@ AST_Toplevel.DEFMETHOD("def_global", function(node) {
 });
 
 AST_Scope.DEFMETHOD("init_scope_vars", function(parent_scope) {
-    this.variables = new Dictionary();  // map name to AST_SymbolVar (variables defined in this scope; includes functions)
-    this.functions = new Dictionary();  // map name to AST_SymbolDefun (functions defined in this scope)
+    this.variables = new Map();         // map name to AST_SymbolVar (variables defined in this scope; includes functions)
+    this.functions = new Map();         // map name to AST_SymbolDefun (functions defined in this scope)
     this.uses_with = false;             // will be set to true if this or some nested scope uses the `with` statement
     this.uses_eval = false;             // will be set to true if this or nested scope uses the global `eval`
     this.parent_scope = parent_scope;   // the parent scope
@@ -458,7 +457,7 @@ AST_Symbol.DEFMETHOD("mark_enclosed", function(options) {
     while (s) {
         push_uniq(s.enclosed, def);
         if (options.keep_fnames) {
-            s.functions.each(function(d) {
+            s.functions.forEach(function(d) {
                 if (keep_name(options.keep_fnames, d.name)) {
                     push_uniq(def.scope.enclosed, d);
                 }
@@ -621,11 +620,11 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
             return true;        // don't descend again in TreeWalker
         }
         if (node instanceof AST_Scope) {
-            node.variables.each(collect);
+            node.variables.forEach(collect);
             return;
         }
         if (node.is_block_scope()) {
-            node.block_scope.variables.each(collect);
+            node.block_scope.variables.forEach(collect);
             return;
         }
         if (node instanceof AST_Label) {
@@ -657,7 +656,7 @@ AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
     options.reserved.forEach(to_avoid);
     this.globals.forEach(add_def);
     this.walk(new TreeWalker(function(node) {
-        if (node instanceof AST_Scope) node.variables.each(add_def);
+        if (node instanceof AST_Scope) node.variables.forEach(add_def);
         if (node instanceof AST_SymbolCatch) add_def(node.definition());
     }));
     return avoid;
@@ -682,7 +681,7 @@ AST_Toplevel.DEFMETHOD("expand_names", function(options) {
     var cname = 0;
     this.globals.forEach(rename);
     this.walk(new TreeWalker(function(node) {
-        if (node instanceof AST_Scope) node.variables.each(rename);
+        if (node instanceof AST_Scope) node.variables.forEach(rename);
         if (node instanceof AST_SymbolCatch) rename(node.definition());
     }));
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -326,6 +326,24 @@ Dictionary.fromObject = function(obj) {
     return dict;
 };
 
+function map_from_object(obj) {
+    var map = new Map();
+    for (var key in obj) {
+        if (HOP(obj, key) && key.charAt(0) === "$") {
+            map.set(key.substr(1), obj[key]);
+        }
+    }
+    return map;
+}
+
+function map_to_object(map) {
+    var obj = Object.create(null);
+    map.forEach(function (value, key) {
+        obj["$" + key] = value;
+    });
+    return obj;
+}
+
 function HOP(obj, prop) {
     return Object.prototype.hasOwnProperty.call(obj, prop);
 }
@@ -369,6 +387,8 @@ export {
     HOP,
     keep_name,
     makePredicate,
+    map_from_object,
+    map_to_object,
     MAP,
     member,
     merge,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -326,6 +326,14 @@ Dictionary.fromObject = function(obj) {
     return dict;
 };
 
+function map_add(map, key, value) {
+    if (map.has(key)) {
+        map.get(key).push(value);
+    } else {
+        map.set(key, [ value ]);
+    }
+}
+
 function map_from_object(obj) {
     var map = new Map();
     for (var key in obj) {
@@ -387,6 +395,7 @@ export {
     HOP,
     keep_name,
     makePredicate,
+    map_add,
     map_from_object,
     map_to_object,
     MAP,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -271,61 +271,6 @@ function all(array, predicate) {
     return true;
 }
 
-function Dictionary() {
-    this._values = Object.create(null);
-    this._size = 0;
-}
-Dictionary.prototype = {
-    set: function(key, val) {
-        if (!this.has(key)) ++this._size;
-        this._values["$" + key] = val;
-        return this;
-    },
-    add: function(key, val) {
-        if (this.has(key)) {
-            this.get(key).push(val);
-        } else {
-            this.set(key, [ val ]);
-        }
-        return this;
-    },
-    get: function(key) { return this._values["$" + key]; },
-    del: function(key) {
-        if (this.has(key)) {
-            --this._size;
-            delete this._values["$" + key];
-        }
-        return this;
-    },
-    has: function(key) { return ("$" + key) in this._values; },
-    each: function(f) {
-        for (var i in this._values)
-            f(this._values[i], i.substr(1));
-    },
-    size: function() {
-        return this._size;
-    },
-    map: function(f) {
-        var ret = [];
-        for (var i in this._values)
-            ret.push(f(this._values[i], i.substr(1)));
-        return ret;
-    },
-    clone: function() {
-        var ret = new Dictionary();
-        for (var i in this._values)
-            ret._values[i] = this._values[i];
-        ret._size = this._size;
-        return ret;
-    },
-    toObject: function() { return this._values; }
-};
-Dictionary.fromObject = function(obj) {
-    var dict = new Dictionary();
-    dict._size = merge(dict._values, obj);
-    return dict;
-};
-
 function map_add(map, key, value) {
     if (map.has(key)) {
         map.get(key).push(value);
@@ -389,7 +334,6 @@ export {
     characters,
     configure_error_stack,
     defaults,
-    Dictionary,
     find_if,
     first_in_statement,
     HOP,

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ export {
 } from "./lib/ast.js";
 export {
     defaults,
-    Dictionary,
+    map_from_object,
     push_uniq,
     string_template,
 } from "./lib/utils.js";

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -217,9 +217,9 @@ function run_compress_tests() {
                 (function(cache) {
                     if (!cache) return;
                     if (!("props" in cache)) {
-                        cache.props = new U.Dictionary();
-                    } else if (!(cache.props instanceof U.Dictionary)) {
-                        cache.props = U.Dictionary.fromObject(cache.props);
+                        cache.props = new Map();
+                    } else if (!(cache.props instanceof Map)) {
+                        cache.props = U.map_from_object(cache.props);
                     }
                 })(test.mangle.cache);
                 output.mangle_names(test.mangle);

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -179,21 +179,6 @@ export class TreeTransformer extends TreeWalker {
 
 export function push_uniq<T>(array: T[], el: T): void;
 
-type DictEachCallback = (val: any, key: string) => any;
-
-export class Dictionary {
-    static fromObject(obj: object): Dictionary;
-    add(key: string, val: any): this;
-    clone(): Dictionary;
-    del(key: string): this;
-    each(fn: DictEachCallback): void;
-    get(key: string): any;
-    has(key: string): boolean;
-    map(fn: DictEachCallback): any[];
-    set(key: string, val: any): this;
-    size(): number;
-}
-
 export function minify(files: string | string[] | { [file: string]: string } | AST_Node, options?: MinifyOptions): MinifyOutput;
 
 export class AST_Node {

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="es2015" />
+
 import { RawSourceMap } from 'source-map';
 
 export type ECMA = 5 | 6 | 7 | 8 | 9;
@@ -178,6 +180,8 @@ export class TreeTransformer extends TreeWalker {
 }
 
 export function push_uniq<T>(array: T[], el: T): void;
+
+export function map_from_object<T>(obj: { [key: string]: T }): Map<string, T>;
 
 export function minify(files: string | string[] | { [file: string]: string } | AST_Node, options?: MinifyOptions): MinifyOutput;
 


### PR DESCRIPTION
Since we're [planning to drop support for running Terser in Node 4](https://github.com/terser-js/terser/pull/271#issuecomment-467666271), and Node 6 fully supports ES2015 Map, we can replace our legacy `Dictionary` class with the native `Map` class. This PR does exactly that.

Breaking changes:
* `Dictionary` has been removed from the main exports. Code relying on `require('terser').Dictionary` will no longer work. I don't think this is too much of a problem: we only really exported it so we could use it to initialize name caches in our own test runner (`test/run-tests.js`).
* `AST_TopLevel.globals`, `AST_Scope.variables` and `AST_Scope.functions` are now `Map`s instead of `Dictionary` objects. Code that consumes Terser's AST may break if they use these properties.

API changes:
* Added a `map_from_object` export which replaces the previous `Dictionary.fromObject` helper, for use by the test runner.

~**Note:** This PR depends on #276. I'm putting this up as a draft PR for now, and I'll mark it ready after #276 is merged.~ Rebased on top of the merged PR! 😄 

Fixes #295