### PR TITLE
Compression function inlining/flattening argument/var names colliding with argument values inner scopes

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5198,6 +5198,7 @@ merge(Compressor.prototype, {
             self.args.forEach(function(value) {
                 value.walk(value_walker);
             });
+			if (arg_vals_outer_refs.size == 0) return true;
             for (var i = 0, len = fn.argnames.length; i < len; i++) {
                 var arg = fn.argnames[i];
                 if (arg instanceof AST_DefaultAssign && arg.left.__unused) continue;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5178,23 +5178,18 @@ merge(Compressor.prototype, {
         }
 
         function can_inject_args_values() {
-            var arg_fns_outer_refs = Object.create(null);
+            var arg_vals_outer_refs = new Set();
             var value_walker = new TreeWalker(function(node) {
                 if (node instanceof AST_Scope) {
-                    var var_list = [];
-                    var var_outer_ref_map = Object.create(null);
+                    var scope_outer_refs = new Set();
                     node.enclosed.forEach(function(def) {
-                        var_list.push(def.name);
-                        var_outer_ref_map[def.name] = true;
+						scope_outer_refs.add(def.name);
                     });
                     node.variables.each(function(def, name) {
-                        var_list.push(name);
-                        var_outer_ref_map[name] = false;
+						scope_outer_refs.delete(name);
                     });
-                    var_list.forEach(function(name) {
-                        if (var_outer_ref_map[name]) {
-                            arg_fns_outer_refs[name] = true;
-                        }
+                    scope_outer_refs.forEach(function(name) {
+                        arg_vals_outer_refs.add(name);
                     });
                     return true;
                 }
@@ -5208,13 +5203,17 @@ merge(Compressor.prototype, {
                 if (arg instanceof AST_DefaultAssign && arg.left.__unused) continue;
                 if (arg instanceof AST_Expansion && arg.expression.__unused) continue;
                 if (arg.__unused) continue;
-                if (arg_fns_outer_refs[arg.name]) return false;
+                if (arg_vals_outer_refs.has(arg.name)) return false;
             }
             for (var i = 0, len = fn.body.length; i < len; i++) {
                 var stat = fn.body[i];
                 if (!(stat instanceof AST_Var)) continue;
                 for (var j = stat.definitions.length; --j >= 0;) {
-                    if (arg_fns_outer_refs[stat.definitions[j].name.name]) return false;
+					var name = stat.definitions[j].name;
+                    if (name instanceof AST_Destructuring
+						|| arg_vals_outer_refs.has(name.name)) {
+						return false;
+					}
                 }
             }
             return true;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5177,6 +5177,46 @@ merge(Compressor.prototype, {
             return true;
         }
 
+        function can_inject_args_values(safe_to_inject) {
+            if (fn.argnames.length > 0 && self.args.length > 0 && !safe_to_inject) return false;
+            var arg_fns_outer_refs = Object.create(null);
+            var value_walker = new TreeWalker(function(node) {
+                if (node instanceof AST_Scope) {
+                    var var_list = [];
+                    var var_outer_ref_map = Object.create(null);
+                    node.enclosed.forEach(function(def) {
+                        var_list.push(def.name);
+                        var_outer_ref_map[def.name] = true;
+                    });
+                    node.variables.each(function(def, name) {
+                        var_list.push(name);
+                        var_outer_ref_map[name] = false;
+                    });
+                    var_list.forEach(function(name) {
+                        if (var_outer_ref_map[name]) {
+                            arg_fns_outer_refs[name] = true;
+                        }
+                    });
+                    return true;
+                }
+                return false;
+            });
+            self.args.forEach(function(value) {
+                value.walk(value_walker);
+            });
+            for (var i = 0, len = fn.argnames.length; i < len; i++) {
+                if (arg_fns_outer_refs[fn.argnames[i].name]) return false;
+            }
+            for (var i = 0, len = fn.body.length; i < len; i++) {
+                var stat = fn.body[i];
+                if (!(stat instanceof AST_Var)) continue;
+                for (var j = stat.definitions.length; --j >= 0;) {
+                    if (arg_fns_outer_refs[stat.definitions[j].name.name]) return false;
+                }
+            }
+            return true;
+        }
+
         function can_inject_vars(block_scoped, safe_to_inject) {
             var len = fn.body.length;
             for (var i = 0; i < len; i++) {
@@ -5224,6 +5264,7 @@ merge(Compressor.prototype, {
             var inline = compressor.option("inline");
             if (!can_inject_vars(block_scoped, inline >= 3 && safe_to_inject)) return false;
             if (!can_inject_args(block_scoped, inline >= 2 && safe_to_inject)) return false;
+            if (!can_inject_args_values(inline >= 2 && safe_to_inject)) return false;
             return !in_loop || in_loop.length == 0 || !is_reachable(fn, in_loop);
         }
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5177,8 +5177,7 @@ merge(Compressor.prototype, {
             return true;
         }
 
-        function can_inject_args_values(safe_to_inject) {
-            if (fn.argnames.length > 0 && self.args.length > 0 && !safe_to_inject) return false;
+        function can_inject_args_values() {
             var arg_fns_outer_refs = Object.create(null);
             var value_walker = new TreeWalker(function(node) {
                 if (node instanceof AST_Scope) {
@@ -5205,7 +5204,11 @@ merge(Compressor.prototype, {
                 value.walk(value_walker);
             });
             for (var i = 0, len = fn.argnames.length; i < len; i++) {
-                if (arg_fns_outer_refs[fn.argnames[i].name]) return false;
+                var arg = fn.argnames[i];
+                if (arg instanceof AST_DefaultAssign && arg.left.__unused) continue;
+                if (arg instanceof AST_Expansion && arg.expression.__unused) continue;
+                if (arg.__unused) continue;
+                if (arg_fns_outer_refs[arg.name]) return false;
             }
             for (var i = 0, len = fn.body.length; i < len; i++) {
                 var stat = fn.body[i];
@@ -5264,7 +5267,7 @@ merge(Compressor.prototype, {
             var inline = compressor.option("inline");
             if (!can_inject_vars(block_scoped, inline >= 3 && safe_to_inject)) return false;
             if (!can_inject_args(block_scoped, inline >= 2 && safe_to_inject)) return false;
-            if (!can_inject_args_values(inline >= 2 && safe_to_inject)) return false;
+            if (!can_inject_args_values()) return false;
             return !in_loop || in_loop.length == 0 || !is_reachable(fn, in_loop);
         }
 

--- a/test/compress/issue-t292.js
+++ b/test/compress/issue-t292.js
@@ -1,0 +1,78 @@
+no_flatten_with_arg_colliding_with_arg_value_inner_scope: {
+    options = {
+        collapse_vars: true,
+        inline: true,
+        reduce_funcs: true,
+        reduce_vars: true,
+        sequences: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var g = ["a"];
+        function problem(arg) {
+            return g.indexOf(arg);
+        }
+        function unused(arg) {
+            return problem(arg);
+        }
+        function a(arg) {
+            return problem(arg);
+        }
+        function b(problem) {
+            return g[problem];
+        }
+        function c(arg) {
+            return b(a(arg));
+        }
+        console.log(c("a"));
+    }
+    expect: {
+        var g=["a"];
+        function problem(arg){return g.indexOf(arg)}
+        console.log(function(problem){return g[problem]}(function(arg){return problem(arg)}("a")));
+    }
+    expect_stdout: "a"
+}
+
+no_flatten_with_var_colliding_with_arg_value_inner_scope: {
+    options = {
+        collapse_vars: true,
+        inline: true,
+        reduce_funcs: true,
+        reduce_vars: true,
+        sequences: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var g = ["a"];
+        function problem(arg) {
+            return g.indexOf(arg);
+        }
+        function unused(arg) {
+            return problem(arg);
+        }
+        function a(arg) {
+            return problem(arg);
+        }
+        function b(test) {
+            var problem = test * 2;
+            console.log(problem);
+            return g[problem];
+        }
+        function c(arg) {
+            return b(a(arg));
+        }
+        console.log(c("a"));
+    }
+    expect: {
+        var g=["a"];
+        function problem(arg){return g.indexOf(arg)}
+        console.log(function(test){var problem=2*test;return console.log(problem),g[problem]}(function(arg){return problem(arg)}("a")));
+    }
+    expect_stdout: [
+        "0",
+        "a",
+    ]
+}


### PR DESCRIPTION
This is the first time I've tried to work on the inner workings of uglify-js / terser. I have some compiler knowledge that helped with understanding the AST and how the compressor works. The solution I came up with to fix #292 does work for my test cases and for the original problem I had, however I can't guarantee it will work for all edge cases. There might also be better ways to solve the problem, but this was the best I could come up with for now. One good thing about how I solved the issue, it only affects the decision about whether to inline / flatten a function, overall working of compression should not be affected other than the cases meeting the conditions where flattening should not happen.

Comments are very welcome :)