### PR TITLE
stop empty lines being emitted when using max_line_len

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -410,10 +410,12 @@ function OutputStream(options) {
                     current_pos++;
                 } else {
                     ensure_line_len();
-                    OUTPUT += "\n";
-                    current_pos++;
-                    current_line++;
-                    current_col = 0;
+                    if (current_col > 0) {
+                        OUTPUT += "\n";
+                        current_pos++;
+                        current_line++;
+                        current_col = 0;
+                    }
 
                     if (/^\s+$/.test(str)) {
                         // reset the semicolon flag, since we didn't print one


### PR DESCRIPTION
When using `max_line_len` empty lines are sometimes output.

I can't really make sense of the structure and functions of this files, so I'm not sure if this is the nicest way of solving the issue. There are so many different ways newlines are printed and so many weird conditionals. But this way does work correctly.