### PR TITLE
add `keep_quoted=strict` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ a double dash to prevent input files being used as option arguments:
                                 `debug`  Add debug prefix and suffix.
                                 `domprops`  Mangle property names that overlaps
                                             with DOM properties.
-                                `keep_quoted`  Only mangle unquoted properties.
+                                `keep_quoted`  Only mangle unquoted properties, quoted
+                                               properties are automatically reserved.
+                                               `strict` disables quoted properties
+                                               being automatically reserved.
                                 `regex`  Only mangle matched property names.
                                 `reserved`  List of names that should not be mangled.
                                 `preamble`  Preamble to prepend to the output. You
@@ -914,6 +917,10 @@ Terser.minify(code, { mangle: { toplevel: true } }).code;
   Pass an empty string `""` to enable, or a non-empty string to set the debug suffix.
 
 - `keep_quoted` (default: `false`) -— Only mangle unquoted property names.
+  - `true` -- Quoted property names are automatically reserved and any unquoted
+    property names will not be mangled.
+  - `"strict"` -- Advanced, all unquoted property names are mangled unless
+    explicitly reserved.
 
 - `regex` (default: `null`) -— Pass a RegExp literal to only mangle property
   names matching the regular expression.

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -795,8 +795,11 @@ var AST_PropAccess = DEFNODE("PropAccess", "expression property", {
     }
 });
 
-var AST_Dot = DEFNODE("Dot", null, {
+var AST_Dot = DEFNODE("Dot", "quote", {
     $documentation: "A dotted property access expression",
+    $propdoc: {
+        quote: "[string] the original quote character when transformed from AST_Sub",
+    },
     _walk: function(visitor) {
         return visitor._visit(this, function() {
             this.expression._walk(visitor);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6532,7 +6532,8 @@ merge(Compressor.prototype, {
                     && property.length <= prop.print_to_string().length + 1) {
                     return make_node(AST_Dot, self, {
                         expression: expr,
-                        property: property
+                        property: property,
+                        quote: prop.quote,
                     }).optimize(compressor);
                 }
             }

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -168,7 +168,7 @@ function minify(files, options) {
             }
             toplevel = options.parse.toplevel;
         }
-        if (quoted_props) {
+        if (quoted_props && options.mangle.properties.keep_quoted !== "strict") {
             reserve_quoted_keys(toplevel, quoted_props);
         }
         if (options.wrap) {

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -178,23 +178,33 @@ function mangle_properties(ast, options) {
     var names_to_mangle = new Set();
     var unmangleable = new Set();
 
+    var keep_quoted_strict = options.keep_quoted === "strict";
+
     // step 1: find candidates to mangle
     ast.walk(new TreeWalker(function(node) {
         if (node instanceof AST_ObjectKeyVal) {
-            if (typeof node.key == "string") {
+            if (typeof node.key == "string" &&
+                (!keep_quoted_strict || !node.quote)) {
                 add(node.key);
             }
         } else if (node instanceof AST_ObjectProperty) {
             // setter or getter, since KeyVal is handled above
-            add(node.key.name);
+            if (!keep_quoted_strict || !node.key.end.quote) {
+                add(node.key.name);
+            }
         } else if (node instanceof AST_Dot) {
             var root = node;
             while (root.expression) {
                 root = root.expression;
             }
-            if (!(root.thedef && root.thedef.undeclared)) add(node.property);
+            if (!(root.thedef && root.thedef.undeclared) &&
+                (!keep_quoted_strict || !node.quote)) {
+                add(node.property);
+            }
         } else if (node instanceof AST_Sub) {
-            addStrings(node.property, add);
+            if (!keep_quoted_strict) {
+                addStrings(node.property, add);
+            }
         } else if (node instanceof AST_Call
             && node.expression.print_to_string() == "Object.defineProperty") {
             addStrings(node.args[1], add);
@@ -204,14 +214,19 @@ function mangle_properties(ast, options) {
     // step 2: transform the tree, renaming properties
     return ast.transform(new TreeTransformer(function(node) {
         if (node instanceof AST_ObjectKeyVal) {
-            if (typeof node.key == "string") {
+            if (typeof node.key == "string" &&
+                (!keep_quoted_strict || !node.quote)) {
                 node.key = mangle(node.key);
             }
         } else if (node instanceof AST_ObjectProperty) {
             // setter or getter
-            node.key.name = mangle(node.key.name);
+            if (!keep_quoted_strict || !node.key.end.quote) {
+                node.key.name = mangle(node.key.name);
+            }
         } else if (node instanceof AST_Dot) {
-            node.property = mangle(node.property);
+            if (!keep_quoted_strict || !node.quote) {
+                node.property = mangle(node.property);
+            }
         } else if (!options.keep_quoted && node instanceof AST_Sub) {
             node.property = mangleStrings(node.property);
         } else if (node instanceof AST_Call

--- a/test/compress/keep_quoted_strict.js
+++ b/test/compress/keep_quoted_strict.js
@@ -1,0 +1,69 @@
+keep_quoted_strict: {
+    options = {
+        evaluate: true,
+        properties: true,
+    },
+    mangle = {
+        properties: {
+            keep_quoted: "strict",
+            reserved: ["propc", "propd"],
+        },
+    }
+    input: {
+        var a = {
+            propa: 1,
+            get propb() { return 2; },
+            propc: 3,
+            get propd() { return 4; },
+        };
+        var b = {
+            "propa": 5,
+            get "propb"() { return 6; },
+            "propc": 7,
+            get "propd"() { return 8; },
+        };
+        var c = {};
+        Object.defineProperty(c, "propa", {"value": 9});
+        Object.defineProperty(c, "propc", {"value": 10});
+        console.log(a.propa, a.propb, a.propc, a["propc"], a.propd, a["propd"]);
+        console.log(b["propa"], b["propb"], b.propc, b["propc"], b.propd, b["propd"]);
+        console.log(c.propa, c["propc"]);
+    }
+    expect: {
+        var a = {
+            p: 1,
+            get o() {
+                return 2;
+            },
+            propc: 3,
+            get propd() {
+                return 4;
+            }
+        };
+        var b = {
+            propa: 5,
+            get propb() {
+                return 6;
+            },
+            propc: 7,
+            get propd() {
+                return 8;
+            }
+        };
+        var c = {};
+        Object.defineProperty(c, "p", {
+            value: 9
+        });
+        Object.defineProperty(c, "propc", {
+            value: 10
+        });
+        console.log(a.p, a.o, a.propc, a.propc, a.propd, a.propd);
+        console.log(b.propa, b.propb, b.propc, b.propc, b.propd, b.propd);
+        console.log(c.p, c.propc);
+    }
+    expect_stdout: [
+        "1 2 3 3 4 4",
+        "5 6 7 7 8 8",
+        "9 10",
+    ]
+}

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -202,7 +202,9 @@ function run_compress_tests() {
                 var quoted_props = test.mangle.properties.reserved;
                 if (!Array.isArray(quoted_props)) quoted_props = [];
                 test.mangle.properties.reserved = quoted_props;
-                U.reserve_quoted_keys(input, quoted_props);
+                if (test.mangle.properties.keep_quoted !== "strict") {
+                    U.reserve_quoted_keys(input, quoted_props);
+                }
             }
             if (test.rename) {
                 input.figure_out_scope(test.mangle);


### PR DESCRIPTION
I made a PR for uglify-js some time back for adding keep_quoted=strict mode which prevents quoted properties from being automatically reserved (which stops unquoted properties of the same name from being mangled). This is much closer to how google-closure-compiler works; it generates less code, more completely obfuscates code and more clearly brings mistakes in code to light. If you mix quoted and unquoted for the same the property with strict-mode, the name mangling will become incorrect and the app will not work correctly, rather than silently fixing it by making any quoted props reserved. It's not as nice, but it's opt-in and for me a more desirable behavior.

Source issue: https://github.com/terser-js/terser/issues/304

@fabiosantoscode I know you said you were busy with Terser 4, but I had some time over and just thought I'd prepare a PR anyway. So it's here when you feel you have the time, I don't mind rebasing if necessary later on.

PS. I kept `quote` instead of `original_quote` because I saw that it is the naming used for all the other AST-nodes which saves the original quote character. It's not for *exactly* the same purpose, but it's rather close. Do you still prefer that I rename it to `original_quote`?

I've also tested it on my large-scale work project with 700KB+ worth of source code. It work perfectly and even helped me discover some places in my code where I had gotten it wrong.