### PR TITLE
fix optimization of `Array` and `new Array`

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5314,19 +5314,11 @@ merge(Compressor.prototype, {
     });
 
     def_optimize(AST_New, function(self, compressor) {
-        if (compressor.option("unsafe")) {
-            var exp = self.expression;
-            if (is_undeclared_ref(exp)) {
-                switch (exp.name) {
-                  case "Object":
-                  case "RegExp":
-                  case "Function":
-                  case "Error":
-                  case "Array":
-                    return make_node(AST_Call, self, self).transform(compressor);
-                }
-            }
-        }
+        if (
+            compressor.option("unsafe") &&
+            is_undeclared_ref(self.expression) &&
+            ["Object", "RegExp", "Function", "Error", "Array"].includes(self.expression.name)
+        ) return make_node(AST_Call, self, self).transform(compressor);
         return self;
     });
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4808,6 +4808,10 @@ merge(Compressor.prototype, {
                     return make_node(AST_Array, self, {
                         elements: self.args
                     }).optimize(compressor);
+                } else if (self.args[0] instanceof AST_Number && self.args[0].value <= 11) {
+                    const elements = [];
+                    for (let i = 0; i < self.args[0].value; i++) elements.push(new AST_Hole);
+                    return new AST_Array({ elements });
                 }
                 break;
               case "Object":
@@ -5310,26 +5314,19 @@ merge(Compressor.prototype, {
     });
 
     def_optimize(AST_New, function(self, compressor) {
-        const {args, expression: exp} = self;
-
-        if (compressor.option("unsafe") && is_undeclared_ref(exp)) {
-            if (["Object", "RegExp", "Function", "Error"].includes(exp.name))
-                return make_node(AST_Call, self, self).transform(compressor);
-
-            if (exp.name === "Array" && args.length < 2) {
-                if (args.length === 0 || args[0].value === 0) return new AST_Array;
-
-                if (args[0].value > 11) {
+        if (compressor.option("unsafe")) {
+            var exp = self.expression;
+            if (is_undeclared_ref(exp)) {
+                switch (exp.name) {
+                  case "Object":
+                  case "RegExp":
+                  case "Function":
+                  case "Error":
+                  case "Array":
                     return make_node(AST_Call, self, self).transform(compressor);
                 }
-
-                const elements = [];
-                for (let i = 0; i < self.args[0].value; i++) elements.push(new AST_Hole);
-
-                return new AST_Array({elements});
             }
         }
-
         return self;
     });
 

--- a/test/compress/array-constructor.js
+++ b/test/compress/array-constructor.js
@@ -24,13 +24,25 @@ array_constructor_unsafe: {
         console.log(new Array(0));
         console.log(new Array(1));
         console.log(new Array(11));
+        console.log(Array(11));
         console.log(new Array(12));
+        console.log(Array(12));
+        console.log(new Array(foo));
+        console.log(Array(foo));
+        console.log(new Array("foo"));
+        console.log(Array("foo"));
     }
     expect: {
         console.log([]);
         console.log([]);
         console.log([,]);
         console.log([,,,,,,,,,,,]);
+        console.log([,,,,,,,,,,,]);
         console.log(Array(12));
+        console.log(Array(12));
+        console.log(Array(foo));
+        console.log(Array(foo));
+        console.log(Array("foo"));
+        console.log(Array("foo"));
     }
 }


### PR DESCRIPTION
Fixes #312. This reverts the previous (incorrect) optimization applied to `AST_New` and instead applies the (correct) optimization to `AST_Call`.