### PR TITLE
Move map_from_object to test-only APIs

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,6 @@ export {
 } from "./lib/ast.js";
 export {
     defaults,
-    map_from_object,
     push_uniq,
     string_template,
 } from "./lib/utils.js";

--- a/main.tests.js
+++ b/main.tests.js
@@ -4,6 +4,9 @@ export * from "./main";
 // TESTS
 export * from "./lib/ast.js";
 export {
+    map_from_object,
+} from "./lib/utils.js";
+export {
     JS_Parse_Error,
     tokenizer,
 } from "./lib/parse.js";

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -184,8 +184,6 @@ export class TreeTransformer extends TreeWalker {
 
 export function push_uniq<T>(array: T[], el: T): void;
 
-export function map_from_object<T>(obj: { [key: string]: T }): Map<string, T>;
-
 export function minify(files: string | string[] | { [file: string]: string } | AST_Node, options?: MinifyOptions): MinifyOutput;
 
 export class AST_Node {


### PR DESCRIPTION
In #300, I added a `map_from_object` helper function that's only used by the test runner. Thanks to the refactor in #288, we can now move this function out of the main bundle.

See [my comment on #288](https://github.com/terser-js/terser/pull/288#issuecomment-473603626).