### PR TITLE
Move safe comps transformations out of `unsafe_comps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,8 +691,8 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   side effects permitting.
 
 - `comparisons` (default: `true`) -- apply certain optimizations to binary nodes,
-  e.g. `!(a <= b) → a > b` (only when `unsafe_comps`), attempts to negate binary
-  nodes, e.g. `a = !b && !c && !d && !e → a=!(b||c||d||e)` etc.
+  e.g. `!(a <= b) → a > b`, attempts to negate binary nodes, e.g.
+  `a = !b && !c && !d && !e → a=!(b||c||d||e)` etc.
 
 - `computed_props` (default: `true`) -- Transforms constant computed properties
   into regular ones: `{["computed"]: 1}` is converted to `{computed: 1}`.
@@ -843,12 +843,8 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   the function having a `prototype`, which arrow functions lack.
   This transform requires that the `ecma` compress option is set to `6` or greater.
 
-- `unsafe_comps` (default: `false`) -- Reverse `<` and `<=` to `>` and `>=` to
-  allow improved compression. This might be unsafe when an at least one of two
-  operands is an object with computed values due the use of methods like `get`,
-  or `valueOf`. This could cause change in execution order after operands in the
-  comparison are switching. Compression only works if both `comparisons` and
-  `unsafe_comps` are both set to true.
+- `unsafe_comps` (default: `false`) -- compress expressions like `a <= b` assuming
+  none of the operands can be (coerced to) `NaN`.
 
 - `unsafe_Function` (default: `false`) -- compress and mangle `Function(args, code)`
   when both `args` and `code` are string literals.

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5012,7 +5012,6 @@ merge(Compressor.prototype, {
                     var comp = new Compressor(compressor.options);
                     ast = ast.transform(comp);
                     ast.figure_out_scope(mangle);
-                    base54.reset();
                     ast.compute_char_frequency(mangle);
                     ast.mangle_names(mangle);
                     var fun;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5656,11 +5656,9 @@ merge(Compressor.prototype, {
                 });
                 self = best_of(compressor, self, negated);
             }
-            if (compressor.option("unsafe_comps")) {
-                switch (self.operator) {
-                  case "<": reverse(">"); break;
-                  case "<=": reverse(">="); break;
-                }
+            switch (self.operator) {
+              case "<": reverse(">"); break;
+              case "<=": reverse(">="); break;
             }
         }
         if (self.operator == "+") {

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -191,7 +191,6 @@ function minify(files, options) {
         if (options.mangle) toplevel.figure_out_scope(options.mangle);
         if (timings) timings.mangle = Date.now();
         if (options.mangle) {
-            base54.reset();
             toplevel.compute_char_frequency(options.mangle);
             toplevel.mangle_names(options.mangle);
         }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -572,7 +572,7 @@ AST_Symbol.DEFMETHOD("global", function() {
     return this.definition().global;
 });
 
-AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options) {
+function _default_mangler_options(options) {
     options = defaults(options, {
         eval        : false,
         ie8         : false,
@@ -589,10 +589,10 @@ AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options) {
     // Never mangle arguments
     push_uniq(options.reserved, "arguments");
     return options;
-});
+}
 
 AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
-    options = this._default_mangler_options(options);
+    options = _default_mangler_options(options);
 
     // We only need to mangle declaration nodes.  Special logic wired
     // into the code generator will display the mangled name if it's
@@ -674,9 +674,8 @@ AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
 });
 
 AST_Toplevel.DEFMETHOD("expand_names", function(options) {
-    base54.reset();
     base54.sort();
-    options = this._default_mangler_options(options);
+    options = _default_mangler_options(options);
     var avoid = this.find_colliding_names(options);
     var cname = 0;
     this.globals.forEach(rename);
@@ -714,7 +713,8 @@ AST_Sequence.DEFMETHOD("tail_node", function() {
 });
 
 AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options) {
-    options = this._default_mangler_options(options);
+    options = _default_mangler_options(options);
+    base54.reset();
     try {
         AST_Node.prototype.print = function(stream, force_parens) {
             this._print(stream, force_parens);

--- a/main.js
+++ b/main.js
@@ -20,7 +20,6 @@ export {
     push_uniq,
     string_template,
 } from "./lib/utils.js";
-export { base54 } from "./lib/scope.js";
 export { Compressor } from "./lib/compress/index.js";
 export { to_ascii } from "./lib/minify.js";
 export { OutputStream } from "./lib/output.js";

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -28,6 +28,7 @@ var remaining = 2 * urls.length;
 function done() {
     if (!--remaining) {
         var failures = [];
+        var sum = { input: 0, output: 0, gzip: 0 };
         urls.forEach(function(url) {
             var info = results[url];
             console.log();
@@ -40,6 +41,9 @@ function done() {
             if (info.code) {
                 failures.push(url);
             }
+            sum.input += info.input;
+            sum.output += info.output;
+            sum.gzip += info.gzip;
         });
         if (failures.length) {
             console.error("Benchmark failed:");
@@ -47,6 +51,13 @@ function done() {
                 console.error(url);
             });
             process.exit(1);
+        } else {
+            console.log();
+            console.log("Subtotal");
+            console.log();
+            console.log("Original:", sum.input, "bytes");
+            console.log("Uglified:", sum.output, "bytes");
+            console.log("GZipped: ", sum.gzip, "bytes");
         }
     }
 }

--- a/test/compress/asm.js
+++ b/test/compress/asm.js
@@ -91,7 +91,7 @@ asm_mixed: {
             function logSum(start, end) {
                 start |= 0, end |= 0;
                 var sum = 0, p = 0, q = 0;
-                for (p = start << 3, q = end << 3; (0 | p) < (0 | q); p = p + 8 | 0) sum += +log(values[p >> 3]);
+                for (p = start << 3, q = end << 3; (0 | q) > (0 | p); p = p + 8 | 0) sum += +log(values[p >> 3]);
                 return +sum;
             }
             function geometricMean(start, end) {

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1144,15 +1144,15 @@ collapse_vars_unary: {
             return delete x;
         }
         function f1(n) {
-            return n > +!!n
+            return n > +!!n;
         }
         function f2(n) {
             var k = 7;
-            return k--
+            return k--;
         }
         function f3(n) {
             var k = 7;
-            return ++k
+            return ++k;
         }
         function f4(n) {
             var k = 8 - n;

--- a/test/compress/comparing.js
+++ b/test/compress/comparing.js
@@ -4,59 +4,40 @@ keep_comparisons: {
         unsafe_comps: false
     }
     input: {
-        var obj1 = {
-            valueOf: function() {triggeredFirst();}
-        }
-        var obj2 = {
-            valueOf: function() {triggeredSecond();}
-        }
+        var obj1, obj2;
         var result1 = obj1 <= obj2;
         var result2 = obj1 <  obj2;
         var result3 = obj1 >= obj2;
         var result4 = obj1 >  obj2;
     }
     expect: {
-        var obj1 = {
-            valueOf: function() {triggeredFirst();}
-        }
-        var obj2 = {
-            valueOf: function() {triggeredSecond();}
-        }
-        var result1 = obj1 <= obj2;
-        var result2 = obj1 <  obj2;
+        var obj1, obj2;
+        var result1 = obj2 >= obj1;
+        var result2 = obj2 > obj1;
         var result3 = obj1 >= obj2;
-        var result4 = obj1 >  obj2;
+        var result4 = obj1 > obj2;
     }
 }
 
-keep_comparisons_with_unsafe_comps: {
+unsafe_comps: {
     options = {
         comparisons: true,
-        unsafe_comps: true
+        conditionals: true,
+        unsafe_comps: true,
     }
     input: {
-        var obj1 = {
-            valueOf: function() {triggeredFirst();}
-        }
-        var obj2 = {
-            valueOf: function() {triggeredSecond();}
-        }
-        var result1 = obj1 <= obj2;
-        var result2 = obj1 <  obj2;
-        var result3 = obj1 >= obj2;
-        var result4 = obj1 >  obj2;
+        var obj1, obj2;
+        obj1 <= obj2 ? f1() : g1();
+        obj1 <  obj2 ? f2() : g2();
+        obj1 >= obj2 ? f3() : g3();
+        obj1 >  obj2 ? f4() : g4();
     }
     expect: {
-        var obj1 = {
-            valueOf: function() {triggeredFirst();}
-        }
-        var obj2 = {
-            valueOf: function() {triggeredSecond();}
-        }
-        var result1 = obj2 >= obj1;
-        var result2 = obj2 >  obj1;
-        var result3 = obj1 >= obj2;
-        var result4 = obj1 >  obj2;
+        var obj1, obj2;
+        obj1 > obj2 ? g1() : f1();
+        obj2 > obj1 ? f2() : g2();
+        obj2 > obj1 ? g3() : f3();
+        obj1 > obj2 ? f4() : g4();
     }
 }
 

--- a/test/compress/const.js
+++ b/test/compress/const.js
@@ -25,7 +25,7 @@ issue_1191: {
     }
     expect: {
         function foo(rot) {
-            (rot < -5 || rot > 5) && bar();
+            (-5 > rot || rot > 5) && bar();
             baz();
         }
     }

--- a/test/compress/issue-1447.js
+++ b/test/compress/issue-1447.js
@@ -40,6 +40,6 @@ conditional_false_stray_else_in_loop: {
             console.log(i);
         }
     }
-    expect_exact: "for(var i=1;i<=4;++i)if(!(i<=2))console.log(i);"
+    expect_exact: "for(var i=1;4>=i;++i)if(!(2>=i))console.log(i);"
     expect_stdout: true
 }

--- a/test/compress/issue-1466.js
+++ b/test/compress/issue-1466.js
@@ -27,10 +27,10 @@ same_variable_in_multiple_for_loop: {
         }
     }
     expect: {
-        for (let o = 0; o < 3; o++) {
+        for (let o = 0; 3 > o; o++) {
             let l = 100;
             console.log(o, l);
-            for (let o = 0; o < 2; o++) {
+            for (let o = 0; 2 > o; o++) {
                 console.log(o, l);
                 let e = 2;
                 console.log(e);
@@ -151,10 +151,10 @@ different_variable_in_multiple_for_loop: {
         }
     }
     expect: {
-        for (let o = 0; o < 3; o++) {
+        for (let o = 0; 3 > o; o++) {
             let l = 100;
             console.log(o, l);
-            for (let o = 0; o < 2; o++) {
+            for (let o = 0; 2 > o; o++) {
                 console.log(o, l);
                 let e = 2;
                 console.log(e);
@@ -437,10 +437,10 @@ more_variable_in_multiple_for: {
         }
     }
     expect: {
-        for (let o = 9, l = 0; l < 20; l += o) {
+        for (let o = 9, l = 0; 20 > l; l += o) {
             let e = o++ + l;
             console.log(o, e, l);
-            for (let l = e, t = e * e, c = 0; c < 10; c++)
+            for (let l = e, t = e * e, c = 0; 10 > c; c++)
                 console.log(o, e, t, l, c);
         }
     }

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -214,7 +214,6 @@ function run_compress_tests() {
             var output = cmp.compress(input);
             output.figure_out_scope(test.mangle);
             if (test.mangle) {
-                U.base54.reset();
                 output.compute_char_frequency(test.mangle);
                 (function(cache) {
                     if (!cache) return;


### PR DESCRIPTION
*What's done:*
1. Moved safe comps transformations out of `unsafe_comps` -> reduce gzipped size
1. Reduced usage of `base54` -> less exports required for running tests
1. Show benchmark subtotal results