### PR TITLE
Allow for custom funcs on Object.prototype

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -2587,7 +2587,7 @@ merge(Compressor.prototype, {
     }
 
     function convert_to_predicate(obj) {
-        for (var key in obj) {
+        for (var key of Object.keys(obj)) {
             obj[key] = makePredicate(obj[key]);
         }
     }


### PR DESCRIPTION
Teeny tiny bugfix. Resolves https://github.com/terser-js/terser/issues/332 to allow for functions added to the Object prototype. 