### PR TITLE
Fix compressed source-maps have non-terminated segments

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -74,12 +74,21 @@ function SourceMap(options) {
     }
 
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
+        var generatedPos = { line: gen_line + options.dest_line_diff, column: gen_col };
         if (orig_map) {
             var info = orig_map.originalPositionFor({
                 line: orig_line,
                 column: orig_col
             });
             if (info.source === null) {
+                if (generatedPos.column !== 0) {
+                    generator.addMapping({
+                        generated: generatedPos,
+                        original: null,
+                        source: null,
+                        name: null
+                    });
+                }
                 return;
             }
             source = info.source;
@@ -88,7 +97,7 @@ function SourceMap(options) {
             name = info.name || name;
         }
         generator.addMapping({
-            generated : { line: gen_line + options.dest_line_diff, column: gen_col },
+            generated : generatedPos,
             original  : { line: orig_line + options.orig_line_diff, column: orig_col },
             source    : source,
             name      : name


### PR DESCRIPTION
Currently when `terser` compresses a given input file that comes
with a source-map, but the source-map does not have mappings for
all code parts in the input file. e.g. the input file has been generated
and some specific code-parts have been generated and are not
originating from any source-file.

In that case if mappings before the "generated code" are collected, and
the original file location for the "generated code" is determined after previous
mappings for the same line have been recorded, Terser just ignores the fact that
there is *no original location* and the previous segment is not terminated. This causes
the "generated code" incorrectly to be mapped to the previous segment/
original source location.