### PR TITLE
fuzz.js: Ignore an error where Acorn is stricter than Terser at parsing

### DIFF
--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -22,6 +22,7 @@ var known_acorn_errors = new RegExp([
   "Comma is not permitted after the rest element",
   "Duplicate export",
   "Expecting Unicode escape sequence",
+  "Export '.*' is not defined",
   "Identifier '.*' has already been declared",
   "Invalid regular expression: .* Unmatched",
   "Invalid regular expression: .* Unterminated group",


### PR DESCRIPTION
Was introduced with ugprade to Acorn 6.1.1.