### PR TITLE
Don't use base54 in tests

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -173,10 +173,7 @@ import {
     PRECEDENCE,
 } from "../parse.js";
 import { OutputStream } from "../output.js";
-import {
-    base54,
-    SymbolDef,
-} from "../scope.js";
+import { SymbolDef } from "../scope.js";
 
 function Compressor(options, false_by_default) {
     if (!(this instanceof Compressor))
@@ -5012,7 +5009,6 @@ merge(Compressor.prototype, {
                     var comp = new Compressor(compressor.options);
                     ast = ast.transform(comp);
                     ast.figure_out_scope(mangle);
-                    base54.reset();
                     ast.compute_char_frequency(mangle);
                     ast.mangle_names(mangle);
                     var fun;

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -14,7 +14,6 @@ import {
 import { parse } from "./parse.js";
 import { OutputStream } from "./output.js";
 import { Compressor } from "./compress/index.js";
-import { base54 } from "./scope.js";
 import { SourceMap } from "./sourcemap.js";
 import {
     mangle_properties,
@@ -191,7 +190,6 @@ function minify(files, options) {
         if (options.mangle) toplevel.figure_out_scope(options.mangle);
         if (timings) timings.mangle = Date.now();
         if (options.mangle) {
-            base54.reset();
             toplevel.compute_char_frequency(options.mangle);
             toplevel.mangle_names(options.mangle);
         }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -572,7 +572,7 @@ AST_Symbol.DEFMETHOD("global", function() {
     return this.definition().global;
 });
 
-AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options) {
+function _default_mangler_options(options) {
     options = defaults(options, {
         eval        : false,
         ie8         : false,
@@ -589,10 +589,10 @@ AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options) {
     // Never mangle arguments
     push_uniq(options.reserved, "arguments");
     return options;
-});
+}
 
 AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
-    options = this._default_mangler_options(options);
+    options = _default_mangler_options(options);
 
     // We only need to mangle declaration nodes.  Special logic wired
     // into the code generator will display the mangled name if it's
@@ -674,9 +674,8 @@ AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
 });
 
 AST_Toplevel.DEFMETHOD("expand_names", function(options) {
-    base54.reset();
     base54.sort();
-    options = this._default_mangler_options(options);
+    options = _default_mangler_options(options);
     var avoid = this.find_colliding_names(options);
     var cname = 0;
     this.globals.forEach(rename);
@@ -714,7 +713,8 @@ AST_Sequence.DEFMETHOD("tail_node", function() {
 });
 
 AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options) {
-    options = this._default_mangler_options(options);
+    options = _default_mangler_options(options);
+    base54.reset();
     try {
         AST_Node.prototype.print = function(stream, force_parens) {
             this._print(stream, force_parens);

--- a/main.js
+++ b/main.js
@@ -20,7 +20,6 @@ export {
     push_uniq,
     string_template,
 } from "./lib/utils.js";
-export { base54 } from "./lib/scope.js";
 export { Compressor } from "./lib/compress/index.js";
 export { to_ascii } from "./lib/minify.js";
 export { OutputStream } from "./lib/output.js";

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -214,7 +214,6 @@ function run_compress_tests() {
             var output = cmp.compress(input);
             output.figure_out_scope(test.mangle);
             if (test.mangle) {
-                U.base54.reset();
                 output.compute_char_frequency(test.mangle);
                 (function(cache) {
                     if (!cache) return;


### PR DESCRIPTION
In general it allows to exclude base54 from exports