### PR TITLE
Fix default function params from Acorn AST

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -203,7 +203,9 @@ import {
             var Type = AST_Binary;
             if(FROM_MOZ_STACK.length > 2) {
                 var p = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 2];
-                if(p === "FunctionDeclaration" || p === "FunctionExpression" || p === "ArrowFunctionExpression") {
+                if(p.type === "FunctionDeclaration"
+                   || p.type === "FunctionExpression"
+                   || p.type === "ArrowFunctionExpression") {
                     Type = AST_DefaultAssign;
                 }
             }

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -68,6 +68,7 @@ import {
     AST_Continue,
     AST_Debugger,
     AST_Default,
+    AST_DefaultAssign,
     AST_DefClass,
     AST_Definitions,
     AST_Defun,
@@ -199,7 +200,14 @@ import {
             });
         },
         AssignmentPattern: function(M) {
-            return new AST_Binary({
+            var Type = AST_Binary;
+            if(FROM_MOZ_STACK.length > 2) {
+                var p = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 2];
+                if(p === "FunctionDeclaration" || p === "FunctionExpression" || p === "ArrowFunctionExpression") {
+                    Type = AST_DefaultAssign;
+                }
+            }
+            return new Type({
                 start: my_start_token(M),
                 end: my_end_token(M),
                 left: from_moz(M.left),

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -117,7 +117,7 @@ describe("spidermonkey export/import sanity test", function() {
         );
     });
 
-    it("should correctly minify AST from from_moz_ast with function param default destructing", () => {
+    it("should correctly minify AST from from_moz_ast with default function parameter", () => {
         const code = "function run(x = 2){}";
         const acornAst = acorn.parse(code, { locations: true });
         const terserAst = UglifyJS.AST_Node.from_mozilla_ast(acornAst);

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var fs = require("fs");
-var exec = require("child_process").exec;
 var acorn = require("acorn");
 var escodegen = require("escodegen");
 var UglifyJS = require("../..");
@@ -115,6 +114,17 @@ describe("spidermonkey export/import sanity test", function() {
         assert.strictEqual(
             from_moz_ast.print_to_string(),
             uglify_ast.print_to_string()
+        );
+    });
+
+    it("should correctly minify AST from from_moz_ast with function param default destructing", () => {
+        const code = "function run(x = 2){}";
+        const acornAst = acorn.parse(code, { locations: true });
+        const terserAst = UglifyJS.AST_Node.from_mozilla_ast(acornAst);
+        const result = UglifyJS.minify(terserAst);
+        assert.strictEqual(
+            result.code,
+            "function run(x=2){}"
         );
     });
 


### PR DESCRIPTION
Contrary to the issue I filed, any default parameter (also without destructuring) fails when using the Acorn AST: `function run(x = 2){}`

Compared to the pr #359, this fixes the issue during the AST conversion.

This was unnoticed because `AST_DefaultAssign` generates the same code as `AST_Binary` and the existing test for the spidermonkey AST only tests parsing and re-generating.
Maybe minifying the existing `spidermonkey/input.js` test file would be a better test?

Fixes #358, Closes #359