### PR TITLE
Fix typo in `keep_fnames` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 
 - `keep_fnames` (default: `false`) -- Pass `true` to prevent the
   compressor from discarding function names. Pass a regular expression to only keep
-  class names matching that regex. Useful for code relying on `Function.prototype.name`.
+  function names matching that regex. Useful for code relying on `Function.prototype.name`.
   See also: the `keep_fnames` [mangle option](#mangle).
 
 - `keep_infinity` (default: `false`) -- Pass `true` to prevent `Infinity` from


### PR DESCRIPTION
It says class names, when it means function names.

(I'm not sure if I should be updating any version numbers, since this is just a docs change, so I'll refrain from doing so.)