### PR TITLE
Use native string repeat

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -49,7 +49,6 @@ import {
     first_in_statement,
     makePredicate,
     noop,
-    repeat_string,
     return_false,
     return_true,
 } from "./utils.js";
@@ -314,7 +313,7 @@ function OutputStream(options) {
     }
 
     function make_indent(back) {
-        return repeat_string(" ", options.indent_start + indentation - back * options.indent_level);
+        return " ".repeat(options.indent_start + indentation - back * options.indent_level);
     }
 
     /* -----[ beautification/minification ]----- */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,15 +68,6 @@ function find_if(func, array) {
     }
 }
 
-function repeat_string(str, i) {
-    if (i <= 0) return "";
-    if (i == 1) return str;
-    var d = repeat_string(str, i >> 1);
-    d += d;
-    if (i & 1) d += str;
-    return d;
-}
-
 function configure_error_stack(fn) {
     Object.defineProperty(fn.prototype, "stack", {
         get: function() {
@@ -309,7 +300,6 @@ export {
     noop,
     push_uniq,
     remove,
-    repeat_string,
     return_false,
     return_null,
     return_this,


### PR DESCRIPTION
I removed `repeat_string` because Nodejs 4 supports native `String.prototype.repeat`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat