### PR TITLE
Get rid regexp for checking $

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -80,7 +80,7 @@ function DEFNODE(type, props, methods, base) {
         ctor.prototype.TYPE = ctor.TYPE = type;
     }
     if (methods) for (i in methods) if (HOP(methods, i)) {
-        if (/^\$/.test(i)) {
+        if (i[0] === "$") {
             ctor[i.substr(1)] = methods[i];
         } else {
             ctor.prototype[i] = methods[i];


### PR DESCRIPTION
Simplified checking for first char without regexp to performance reason.