### PR TITLE
Optimize has_nlb function

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -152,6 +152,8 @@ import {
 } from "./parse.js";
 
 var EXPECT_DIRECTIVE = /^$|[;{][\s\n]*$/;
+const CODE_LINE_BREAK = 10;
+const CODE_SPACE = 32;
 
 function is_some_comments(comment) {
     // multiline comment
@@ -569,8 +571,19 @@ function OutputStream(options) {
     }
 
     function has_nlb() {
-        var index = OUTPUT.lastIndexOf("\n");
-        return /^ *$/.test(OUTPUT.slice(index + 1));
+        let n = OUTPUT.length - 1;
+        while (n >= 0) {
+            const code = OUTPUT.charCodeAt(n);
+            if (code === CODE_LINE_BREAK) {
+                return true;
+            }
+
+            if (code !== CODE_SPACE) {
+                return false;
+            }
+            n--;
+        }
+        return true;
     }
 
     function prepend_comments(node) {


### PR DESCRIPTION
I refactored checking for nlb without using regexp. It works 3-4x faster in v8 engine.
https://jsperf.com/terser-has-nlb