### PR TITLE
Split utils to separate files

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -48,7 +48,7 @@ import {
     MAP,
     noop,
     string_template,
-} from "./utils.js";
+} from "./utils/index.js";
 import { parse } from "./parse.js";
 
 function DEFNODE(type, props, methods, base) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -45,7 +45,6 @@
 
 import {
     defaults,
-    first_in_statement,
     HOP,
     keep_name,
     makePredicate,
@@ -59,7 +58,8 @@ import {
     return_this,
     return_true,
     string_template,
-} from "../utils.js";
+} from "../utils/index.js";
+import { first_in_statement, } from "../utils/first_in_statement.js";
 import {
     AST_Accessor,
     AST_Array,

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -6,7 +6,7 @@ import {
     map_from_object,
     map_to_object,
     HOP,
-} from "./utils.js";
+} from "./utils/index.js";
 import {
     AST_Node,
     AST_Toplevel,

--- a/lib/output.js
+++ b/lib/output.js
@@ -45,13 +45,12 @@
 
 import {
     defaults,
-    first_in_statement,
     makePredicate,
     noop,
     return_false,
     return_true,
-} from "./utils.js";
-
+} from "./utils/index.js";
+import { first_in_statement } from "./utils/first_in_statement.js";
 import {
     AST_Array,
     AST_Arrow,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -49,7 +49,7 @@ import {
     defaults,
     HOP,
     makePredicate,
-} from "./utils.js";
+} from "./utils/index.js";
 import {
     AST_Accessor,
     AST_Array,

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -47,7 +47,7 @@
 import {
     defaults,
     push_uniq,
-} from "./utils";
+} from "./utils/index.js";
 import { base54 } from "./scope";
 import {
     AST_Call,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -53,7 +53,7 @@ import {
     return_this,
     return_true,
     string_template,
-} from "./utils.js";
+} from "./utils/index.js";
 import {
     AST_Arrow,
     AST_Block,

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -46,7 +46,7 @@
 import MOZ_SourceMap from "source-map";
 import {
     defaults,
-} from "./utils.js";
+} from "./utils/index.js";
 
 // a small wrapper around fitzgen's source-map library
 function SourceMap(options) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -87,7 +87,7 @@ import {
 import {
     MAP,
     noop,
-} from "./utils.js";
+} from "./utils/index.js";
 
 (function() {
 

--- a/lib/utils/first_in_statement.js
+++ b/lib/utils/first_in_statement.js
@@ -1,0 +1,26 @@
+import { AST_Binary, AST_Conditional, AST_Dot, AST_Sequence, AST_Statement, AST_Sub, AST_UnaryPostfix } from "../ast.js";
+
+// return true if the node at the top of the stack (that means the
+// innermost node in the current output) is lexically the first in
+// a statement.
+function first_in_statement(stack) {
+    let node = stack.parent(-1);
+    for (let i = 0, p; p = stack.parent(i); i++) {
+        if (p instanceof AST_Statement && p.body === node)
+            return true;
+        if ((p instanceof AST_Sequence && p.expressions[0] === node) ||
+            (p.TYPE === "Call" && p.expression === node) ||
+            (p instanceof AST_Dot && p.expression === node) ||
+            (p instanceof AST_Sub && p.expression === node) ||
+            (p instanceof AST_Conditional && p.condition === node) ||
+            (p instanceof AST_Binary && p.left === node) ||
+            (p instanceof AST_UnaryPostfix && p.expression === node)
+        ) {
+            node = p;
+        } else {
+            return false;
+        }
+    }
+}
+
+export { first_in_statement };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -43,16 +43,6 @@
 
 "use strict";
 
-import {
-    AST_Binary,
-    AST_Conditional,
-    AST_Dot,
-    AST_Sequence,
-    AST_Statement,
-    AST_Sub,
-    AST_UnaryPostfix,
-} from "./ast.js";
-
 function characters(str) {
     return str.split("");
 }
@@ -212,29 +202,6 @@ function HOP(obj, prop) {
     return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-// return true if the node at the top of the stack (that means the
-// innermost node in the current output) is lexically the first in
-// a statement.
-function first_in_statement(stack) {
-    var node = stack.parent(-1);
-    for (var i = 0, p; p = stack.parent(i); i++) {
-        if (p instanceof AST_Statement && p.body === node)
-            return true;
-        if ((p instanceof AST_Sequence      && p.expressions[0] === node) ||
-            (p.TYPE == "Call"               && p.expression === node ) ||
-            (p instanceof AST_Dot           && p.expression === node ) ||
-            (p instanceof AST_Sub           && p.expression === node ) ||
-            (p instanceof AST_Conditional   && p.condition === node  ) ||
-            (p instanceof AST_Binary        && p.left === node       ) ||
-            (p instanceof AST_UnaryPostfix  && p.expression === node )
-        ) {
-            node = p;
-        } else {
-            return false;
-        }
-    }
-}
-
 function keep_name(keep_setting, name) {
     return keep_setting === true
         || (keep_setting instanceof RegExp && keep_setting.test(name));
@@ -243,7 +210,6 @@ function keep_name(keep_setting, name) {
 export {
     characters,
     defaults,
-    first_in_statement,
     HOP,
     keep_name,
     makePredicate,

--- a/main.js
+++ b/main.js
@@ -126,7 +126,7 @@ export {
     defaults,
     push_uniq,
     string_template,
-} from "./lib/utils.js";
+} from "./lib/utils/index.js";
 export { base54 } from "./lib/scope.js";
 export { Compressor } from "./lib/compress/index.js";
 export { to_ascii } from "./lib/minify.js";

--- a/main.tests.js
+++ b/main.tests.js
@@ -5,7 +5,7 @@ export * from "./main";
 export * from "./lib/ast.js";
 export {
     map_from_object,
-} from "./lib/utils.js";
+} from "./lib/utils/index.js";
 export {
     JS_Parse_Error,
     tokenizer,


### PR DESCRIPTION
It gets rid of one of circular dependency warnings during build.

Based on #376 
