### PR TITLE
Cache args_as_names

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3915,9 +3915,11 @@ merge(Compressor.prototype, {
             if (vars_found > 0) {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];
-                vars.forEach(function(def, name) {
-                    if (self instanceof AST_Lambda
-                        && self.args_as_names().some((x) => x.name === def.name.name)) {
+                const args_as_names = self.args_as_names();
+                const isAstLambda = self instanceof AST_Lambda;
+                vars.forEach((def, name) => {
+                    if (isAstLambda
+                        && args_as_names.some((x) => x.name === def.name.name)) {
                         vars.delete(name);
                     } else {
                         def = def.clone();

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3916,10 +3916,8 @@ merge(Compressor.prototype, {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];
                 const args_as_names = self.args_as_names();
-                const isAstLambda = self instanceof AST_Lambda;
                 vars.forEach((def, name) => {
-                    if (isAstLambda
-                        && args_as_names.some((x) => x.name === def.name.name)) {
+                    if (args_as_names.some((x) => x.name === def.name.name)) {
                         vars.delete(name);
                     } else {
                         def = def.clone();


### PR DESCRIPTION
I cached `self.args_as_names()` before `forEach`. `args_as_names` quite heavy method.