### PR TITLE
Refactored Compress to es6 class

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1268,12 +1268,13 @@ TreeWalker.prototype = {
 };
 
 // Tree transformer helpers.
-function TreeTransformer(before, after) {
-    TreeWalker.call(this);
-    this.before = before;
-    this.after = after;
+class TreeTransformer extends TreeWalker {
+    constructor(before, after) {
+        super();
+        this.before = before;
+        this.after = after;
+    }
 }
-TreeTransformer.prototype = new TreeWalker;
 
 export {
     AST_Accessor,

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -175,127 +175,128 @@ import {
     SymbolDef,
 } from "../scope.js";
 
-function Compressor(options, false_by_default) {
-    if (!(this instanceof Compressor))
-        return new Compressor(options, false_by_default);
-    TreeTransformer.call(this, this.before, this.after);
-    if (options.defaults !== undefined && !options.defaults) false_by_default = true;
-    this.options = defaults(options, {
-        arguments     : false,
-        arrows        : !false_by_default,
-        booleans      : !false_by_default,
-        booleans_as_integers : false,
-        collapse_vars : !false_by_default,
-        comparisons   : !false_by_default,
-        computed_props: !false_by_default,
-        conditionals  : !false_by_default,
-        dead_code     : !false_by_default,
-        defaults      : true,
-        directives    : !false_by_default,
-        drop_console  : false,
-        drop_debugger : !false_by_default,
-        ecma          : 5,
-        evaluate      : !false_by_default,
-        expression    : false,
-        global_defs   : false,
-        hoist_funs    : false,
-        hoist_props   : !false_by_default,
-        hoist_vars    : false,
-        ie8           : false,
-        if_return     : !false_by_default,
-        inline        : !false_by_default,
-        join_vars     : !false_by_default,
-        keep_classnames: false,
-        keep_fargs    : true,
-        keep_fnames   : false,
-        keep_infinity : false,
-        loops         : !false_by_default,
-        module        : false,
-        negate_iife   : !false_by_default,
-        passes        : 1,
-        properties    : !false_by_default,
-        pure_getters  : !false_by_default && "strict",
-        pure_funcs    : null,
-        reduce_funcs  : !false_by_default,
-        reduce_vars   : !false_by_default,
-        sequences     : !false_by_default,
-        side_effects  : !false_by_default,
-        switches      : !false_by_default,
-        top_retain    : null,
-        toplevel      : !!(options && options["top_retain"]),
-        typeofs       : !false_by_default,
-        unsafe        : false,
-        unsafe_arrows : false,
-        unsafe_comps  : false,
-        unsafe_Function: false,
-        unsafe_math   : false,
-        unsafe_methods: false,
-        unsafe_proto  : false,
-        unsafe_regexp : false,
-        unsafe_undefined: false,
-        unused        : !false_by_default,
-        warnings      : false,
-    }, true);
-    var global_defs = this.options["global_defs"];
-    if (typeof global_defs == "object") for (var key in global_defs) {
-        if (key[0] === "@" && HOP(global_defs, key)) {
-            global_defs[key.slice(1)] = parse(global_defs[key], {
-                expression: true
-            });
+class Compressor extends TreeWalker {
+    constructor(options, false_by_default) {
+        super();
+        if (options.defaults !== undefined && !options.defaults) false_by_default = true;
+        this.options = defaults(options, {
+            arguments     : false,
+            arrows        : !false_by_default,
+            booleans      : !false_by_default,
+            booleans_as_integers : false,
+            collapse_vars : !false_by_default,
+            comparisons   : !false_by_default,
+            computed_props: !false_by_default,
+            conditionals  : !false_by_default,
+            dead_code     : !false_by_default,
+            defaults      : true,
+            directives    : !false_by_default,
+            drop_console  : false,
+            drop_debugger : !false_by_default,
+            ecma          : 5,
+            evaluate      : !false_by_default,
+            expression    : false,
+            global_defs   : false,
+            hoist_funs    : false,
+            hoist_props   : !false_by_default,
+            hoist_vars    : false,
+            ie8           : false,
+            if_return     : !false_by_default,
+            inline        : !false_by_default,
+            join_vars     : !false_by_default,
+            keep_classnames: false,
+            keep_fargs    : true,
+            keep_fnames   : false,
+            keep_infinity : false,
+            loops         : !false_by_default,
+            module        : false,
+            negate_iife   : !false_by_default,
+            passes        : 1,
+            properties    : !false_by_default,
+            pure_getters  : !false_by_default && "strict",
+            pure_funcs    : null,
+            reduce_funcs  : !false_by_default,
+            reduce_vars   : !false_by_default,
+            sequences     : !false_by_default,
+            side_effects  : !false_by_default,
+            switches      : !false_by_default,
+            top_retain    : null,
+            toplevel      : !!(options && options["top_retain"]),
+            typeofs       : !false_by_default,
+            unsafe        : false,
+            unsafe_arrows : false,
+            unsafe_comps  : false,
+            unsafe_Function: false,
+            unsafe_math   : false,
+            unsafe_methods: false,
+            unsafe_proto  : false,
+            unsafe_regexp : false,
+            unsafe_undefined: false,
+            unused        : !false_by_default,
+            warnings      : false,
+        }, true);
+        var global_defs = this.options["global_defs"];
+        if (typeof global_defs == "object") for (var key in global_defs) {
+            if (key[0] === "@" && HOP(global_defs, key)) {
+                global_defs[key.slice(1)] = parse(global_defs[key], {
+                    expression: true
+                });
+            }
         }
-    }
-    if (this.options["inline"] === true) this.options["inline"] = 3;
-    var pure_funcs = this.options["pure_funcs"];
-    if (typeof pure_funcs == "function") {
-        this.pure_funcs = pure_funcs;
-    } else {
-        this.pure_funcs = pure_funcs ? function(node) {
-            return !pure_funcs.includes(node.expression.print_to_string());
-        } : return_true;
-    }
-    var top_retain = this.options["top_retain"];
-    if (top_retain instanceof RegExp) {
-        this.top_retain = function(def) {
-            return top_retain.test(def.name);
-        };
-    } else if (typeof top_retain == "function") {
-        this.top_retain = top_retain;
-    } else if (top_retain) {
-        if (typeof top_retain == "string") {
-            top_retain = top_retain.split(/,/);
+        if (this.options["inline"] === true) this.options["inline"] = 3;
+        var pure_funcs = this.options["pure_funcs"];
+        if (typeof pure_funcs == "function") {
+            this.pure_funcs = pure_funcs;
+        } else {
+            this.pure_funcs = pure_funcs ? function(node) {
+                return !pure_funcs.includes(node.expression.print_to_string());
+            } : return_true;
         }
-        this.top_retain = function(def) {
-            return top_retain.includes(def.name);
+        var top_retain = this.options["top_retain"];
+        if (top_retain instanceof RegExp) {
+            this.top_retain = function(def) {
+                return top_retain.test(def.name);
+            };
+        } else if (typeof top_retain == "function") {
+            this.top_retain = top_retain;
+        } else if (top_retain) {
+            if (typeof top_retain == "string") {
+                top_retain = top_retain.split(/,/);
+            }
+            this.top_retain = function(def) {
+                return top_retain.includes(def.name);
+            };
+        }
+        if (this.options["module"]) {
+            this.directives["use strict"] = true;
+            this.options["toplevel"] = true;
+        }
+        var toplevel = this.options["toplevel"];
+        this.toplevel = typeof toplevel == "string" ? {
+            funcs: /funcs/.test(toplevel),
+            vars: /vars/.test(toplevel)
+        } : {
+            funcs: toplevel,
+            vars: toplevel
         };
+        var sequences = this.options["sequences"];
+        this.sequences_limit = sequences == 1 ? 800 : sequences | 0;
+        this.warnings_produced = {};
     }
-    if (this.options["module"]) {
-        this.directives["use strict"] = true;
-        this.options["toplevel"] = true;
-    }
-    var toplevel = this.options["toplevel"];
-    this.toplevel = typeof toplevel == "string" ? {
-        funcs: /funcs/.test(toplevel),
-        vars: /vars/.test(toplevel)
-    } : {
-        funcs: toplevel,
-        vars: toplevel
-    };
-    var sequences = this.options["sequences"];
-    this.sequences_limit = sequences == 1 ? 800 : sequences | 0;
-    this.warnings_produced = {};
-}
 
-Compressor.prototype = new TreeTransformer;
-Object.assign(Compressor.prototype, {
-    option: function(key) { return this.options[key]; },
-    exposed: function(def) {
+    option(key) {
+        return this.options[key];
+    }
+
+    exposed(def) {
         if (def.export) return true;
         if (def.global) for (var i = 0, len = def.orig.length; i < len; i++)
             if (!this.toplevel[def.orig[i] instanceof AST_SymbolDefun ? "funcs" : "vars"])
                 return true;
         return false;
-    },
-    in_boolean_context: function() {
+    }
+
+    in_boolean_context() {
         if (!this.option("booleans")) return false;
         var self = this.self();
         for (var i = 0, p; p = this.parent(i); i++) {
@@ -315,8 +316,9 @@ Object.assign(Compressor.prototype, {
                 return false;
             }
         }
-    },
-    compress: function(node) {
+    }
+
+    compress(node) {
         node = node.resolve_defines(this);
         if (this.option("expression")) {
             node.process_expression(true);
@@ -354,13 +356,15 @@ Object.assign(Compressor.prototype, {
             node.process_expression(false);
         }
         return node;
-    },
-    info: function() {
+    }
+
+    info() {
         if (this.options.warnings == "verbose") {
             AST_Node.warn.apply(AST_Node, arguments);
         }
-    },
-    warn: function(text, props) {
+    }
+
+    warn(text, props) {
         if (this.options.warnings) {
             // only emit unique warnings
             var message = string_template(text, props);
@@ -369,11 +373,12 @@ Object.assign(Compressor.prototype, {
                 AST_Node.warn.apply(AST_Node, arguments);
             }
         }
-    },
-    clear_warnings: function() {
+    }
+
+    clear_warnings() {
         this.warnings_produced = {};
-    },
-    before: function(node, descend, in_list) {
+    }
+    before(node, descend, in_list) {
         if (node._squeezed) return node;
         var was_scope = false;
         if (node instanceof AST_Scope) {
@@ -401,7 +406,7 @@ Object.assign(Compressor.prototype, {
         if (opt === node) opt._squeezed = true;
         return opt;
     }
-});
+}
 
 (function() {
 


### PR DESCRIPTION
I refactored Compress with es2015 class declaration. To improve readability and avoid to legacy inheritance with merging prototypes.