### PR TITLE
Rewrite element instead of splice

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1906,7 +1906,7 @@ class Compressor extends TreeWalker {
                         CHANGED = true;
                         stat = stat.clone();
                         stat.alternative = next;
-                        statements.splice(i, 1, stat.transform(compressor));
+                        statements[i] = stat.transform(compressor);
                         statements.splice(j, 1);
                         continue;
                     }
@@ -1920,7 +1920,7 @@ class Compressor extends TreeWalker {
                         stat.alternative = next || make_node(AST_Return, stat, {
                             value: null
                         });
-                        statements.splice(i, 1, stat.transform(compressor));
+                        statements[i] = stat.transform(compressor);
                         if (next) statements.splice(j, 1);
                         continue;
                     }
@@ -1944,7 +1944,7 @@ class Compressor extends TreeWalker {
                                 })
                             ]
                         });
-                        statements.splice(i, 1, stat.transform(compressor));
+                        statements[i] = stat.transform(compressor);
                         statements.splice(j, 1);
                         continue;
                     }


### PR DESCRIPTION
I got rid of `splice` for replacing array's element.