### PR TITLE
Simplify DEFNODE constructor

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -57,9 +57,9 @@ function DEFNODE(type, props, methods, base = AST_Node) {
     var self_props = props;
     if (base && base.PROPS)
         props = props.concat(base.PROPS);
-    var proto = base && Object.create(base.prototype);
+    const proto = base && Object.create(base.prototype);
 
-    var ctor = function (initProps) {
+    const ctor = function (initProps) {
         if (initProps) {
             for (const key of props) {
                 this[key] = initProps[key];

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -57,28 +57,30 @@ function DEFNODE(type, props, methods, base = AST_Node) {
     var self_props = props;
     if (base && base.PROPS)
         props = props.concat(base.PROPS);
-    var code = "return function AST_" + type + "(props){ if (props) { ";
-    for (var i = props.length; --i >= 0;) {
-        code += "this." + props[i] + " = props." + props[i] + ";";
-    }
-    var proto = base && new base;
-    if (proto && proto.initialize || (methods && methods.initialize))
-        code += "this.initialize();";
-    code += "}}";
-    var ctor = new Function(code)();
+    var proto = base && Object.create(base.prototype);
+
+    var ctor = function (initProps) {
+        if (initProps) {
+            for (const key of props) {
+                this[key] = initProps[key];
+            }
+        }
+        this.initialize && this.initialize();
+    };
+    Object.defineProperty(ctor, "name", {value: `AST_${type}`});
     if (proto) {
         ctor.prototype = proto;
         ctor.BASE = base;
     }
     if (base) base.SUBCLASSES.push(ctor);
     ctor.prototype.CTOR = ctor;
-    ctor.PROPS = props || null;
+    ctor.PROPS = props;
     ctor.SELF_PROPS = self_props;
     ctor.SUBCLASSES = [];
     if (type) {
         ctor.prototype.TYPE = ctor.TYPE = type;
     }
-    if (methods) for (i in methods) if (HOP(methods, i)) {
+    if (methods) for (const i in methods) if (HOP(methods, i)) {
         if (i[0] === "$") {
             ctor[i.substr(1)] = methods[i];
         } else {


### PR DESCRIPTION
I simplified creating node construcor. I got rid of `eval` and used function declaration.