### PR TITLE
Fix self.args_as_names error

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3922,7 +3922,7 @@ class Compressor extends TreeWalker {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];
                 const is_lambda = self instanceof AST_Lambda;
-                const args_as_names = self.args_as_names();
+                const args_as_names = is_lambda ? self.args_as_names() : null;
                 vars.forEach((def, name) => {
                     if (is_lambda && args_as_names.some((x) => x.name === def.name.name)) {
                         vars.delete(name);


### PR DESCRIPTION
Fixes bug with `args_as_names is not a function`