### PR TITLE
Fix Content-Type return for SVG logo usage on GH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 terser
 ======
 
-![Terser](https://raw.githubusercontent.com/terser-js/terser/master/logo.svg)
+![Terser](https://raw.githubusercontent.com/terser-js/terser/master/logo.svg?sanitize=true)
 
   [![NPM Version][npm-image]][npm-url]
   [![NPM Downloads][downloads-image]][downloads-url]
@@ -47,7 +47,7 @@ From NPM for use as a command line app:
 From NPM for programmatic use:
 
     npm install terser
-    
+
 # Command line usage
 
     terser [input files] [options]
@@ -263,7 +263,7 @@ way to use this is to use the `regex` option like so:
 terser example.js -c -m --mangle-props regex=/_$/
 ```
 
-This will mangle all properties that start with an 
+This will mangle all properties that start with an
 underscore. So you can use it to mangle internal methods.
 
 By default, it will mangle all properties in the

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 terser
 ======
 
-![Terser](https://raw.githubusercontent.com/terser-js/terser/master/logo.svg?sanitize=true)
+<img src="https://raw.githubusercontent.com/terser-js/terser/master/logo.svg?sanitize=true" alt="Terser" width="450" height="190">
 
   [![NPM Version][npm-image]][npm-url]
   [![NPM Downloads][downloads-image]][downloads-url]


### PR DESCRIPTION
* Show the GH sanitized SVG. Usually the MIME Content-Type returned is `text/plain` instead of the wanted `image/svg+xml`

Needs:
* Ideally should constrain this with HTML `width` and `height` `img` tag instead of markdown so it's not hugely wide with Xthexder's Wide Github userscript unless it is not minded. Completed in 96578057e1bb4f9564bec4c31d5b20c37cdd035a

Note:
* Trailing white-space omitted by my editor automatically... hope this isn't an issue. Most of the time it isn't.

Refs:
* https://github.community/t5/How-to-use-Git-and-GitHub/Embedding-a-SVG/td-p/2192

Post #415