### PR TITLE
add option mangle.properties.undeclared: boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,11 @@ Terser.minify(code, { mangle: { toplevel: true } }).code;
 - `reserved` (default: `[]`) — Do not mangle property names listed in the
   `reserved` array.
 
+- `undeclared` (default: `false`) - Mangle those names when they are accessed
+  as properties of known top level variables but their declarations are never
+  found in input code. May be useful when only minifying parts of a project.
+  See [#397](https://github.com/terser-js/terser/issues/397) for more details.
+
 ## Output options
 
 The code generator tries to output shortest code possible by default.  In

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -145,6 +145,7 @@ function mangle_properties(ast, options) {
         only_cache: false,
         regex: null,
         reserved: null,
+        undeclared: false,
     }, true);
 
     var reserved_option = options.reserved;
@@ -192,11 +193,15 @@ function mangle_properties(ast, options) {
                 add(node.key.name);
             }
         } else if (node instanceof AST_Dot) {
-            var root = node;
-            while (root.expression) {
-                root = root.expression;
+            var declared = !!options.undeclared;
+            if (!declared) {
+                var root = node;
+                while (root.expression) {
+                    root = root.expression;
+                }
+                declared = !(root.thedef && root.thedef.undeclared);
             }
-            if (!(root.thedef && root.thedef.undeclared) &&
+            if (declared &&
                 (!keep_quoted_strict || !node.quote)) {
                 add(node.property);
             }

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -2452,3 +2452,37 @@ mangle_properties_which_matches_pattern: {
         console.log(acd);
     }
 }
+
+skip_undeclared_properties_by_default: {
+    mangle = {
+        cache: {
+            props: { '$Bar': 'a' }
+        },
+        properties: {},
+        toplevel: true
+    }
+    input: {
+        var Foo = { foo: function() { return Bar.bar() } };
+    }
+    expect: {
+        var r={o:function(){return a.bar()}};
+    }
+}
+
+mangle_undeclared_properties: {
+    mangle = {
+        cache: {
+            props: { '$Bar': 'a' }
+        },
+        properties: {
+            undeclared: true
+        },
+        toplevel: true
+    }
+    input: {
+        var Foo = { foo: function() { return Bar.bar() } };
+    }
+    expect: {
+        var r={o:function(){return a.t()}};
+    }
+}


### PR DESCRIPTION
This will fix #397 by adding a option of `mangle.properties.undeclared = true`, which is `false` by default to keep backwards compatible.