### PR TITLE
Workaround for V8's RegExp line terminator bug

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -47,6 +47,7 @@ import {
     defaults,
     makePredicate,
     noop,
+    regexp_source_fix,
     return_false,
     return_true,
 } from "./utils/index.js";
@@ -1956,9 +1957,7 @@ function OutputStream(options) {
 
     DEFPRINT(AST_RegExp, function(self, output) {
         var regexp = self.getValue();
-        var str = regexp.toString()
-            // Work around a v8 issue reproducible in node 12:
-            .replace(/\\\n/gm, "\\\\\\n");
+        var str = regexp_source_fix(regexp.toString());
         str = output.to_utf8(str);
         output.print(str);
         var p = output.parent();

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -207,6 +207,23 @@ function keep_name(keep_setting, name) {
         || (keep_setting instanceof RegExp && keep_setting.test(name));
 }
 
+var lineTerminatorEscape = {
+    "\n": "n",
+    "\r": "r",
+    "\u2028": "u2028",
+    "\u2029": "u2029",
+};
+function regexp_source_fix(source) {
+    // V8 does not escape line terminators in regexp patterns
+    return source
+        .replace(/[\n\r\u2028\u2029]/g, function (match, offset) {
+            var escaped = source[offset - 1] == "\\"
+                && (source[offset - 2] != "\\"
+                || /(?:^|[^\\])(?:\\{2})*$/.test(source.slice(0, offset - 1)));
+            return (escaped ? "" : "\\") + lineTerminatorEscape[match];
+        });
+}
+
 export {
     characters,
     defaults,
@@ -221,6 +238,7 @@ export {
     mergeSort,
     noop,
     push_uniq,
+    regexp_source_fix,
     remove,
     return_false,
     return_null,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -214,14 +214,13 @@ var lineTerminatorEscape = {
     "\u2029": "u2029",
 };
 function regexp_source_fix(source) {
-    // V8 does not escape line terminators in regexp patterns
-    return source
-        .replace(/[\n\r\u2028\u2029]/g, function (match, offset) {
-            var escaped = source[offset - 1] == "\\"
-                && (source[offset - 2] != "\\"
-                || /(?:^|[^\\])(?:\\{2})*$/.test(source.slice(0, offset - 1)));
-            return (escaped ? "" : "\\") + lineTerminatorEscape[match];
-        });
+    // V8 does not escape line terminators in regexp patterns in node 12
+    return source.replace(/[\n\r\u2028\u2029]/g, function (match, offset) {
+        var escaped = source[offset - 1] == "\\"
+            && (source[offset - 2] != "\\"
+            || /(?:^|[^\\])(?:\\{2})*$/.test(source.slice(0, offset - 1)));
+        return (escaped ? "" : "\\") + lineTerminatorEscape[match];
+    });
 }
 
 export {

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1748,3 +1748,39 @@ global_hasOwnProperty: {
         hasOwnProperty.call(a['b'], b)
     }
 }
+
+issue_399: {
+    options = {
+        unsafe: true,
+        evaluate: true,
+        unsafe_regexp: true
+    }
+    input: {
+        console.log(RegExp("\\\nfo\n[\n]o\\bbb"));
+        console.log(RegExp("\n"));
+        console.log(RegExp("\\n"));
+        console.log(RegExp("\\\n"));
+        console.log(RegExp("\\\\n"));
+        console.log(RegExp("\\\\\n"));
+        console.log(RegExp("\\\\\\n"));
+        console.log(RegExp("\\\\\\\n"));
+        console.log(RegExp("\r"));
+        console.log(RegExp("\u2028"));
+        console.log(RegExp("\u2029"));
+        console.log(RegExp("\n\r\u2028\u2029"));
+    }
+    expect: {
+        console.log(/\nfo\n[\n]o\bbb/);
+        console.log(/\n/);
+        console.log(/\n/);
+        console.log(/\n/);
+        console.log(/\\n/);
+        console.log(/\\\n/);
+        console.log(/\\\n/);
+        console.log(/\\\n/);
+        console.log(/\r/);
+        console.log(/\u2028/);
+        console.log(/\u2029/);
+        console.log(/\n\r\u2028\u2029/);
+    }
+}


### PR DESCRIPTION
Fixed the workaround of V8's RegExp line terminator bug as discussed [here](https://github.com/terser-js/terser/commit/de01b3141ebbfa2ab7ac909ed08725b06eba5f57#r34722043).

The `regexp_source_fix` can be used for both the source of a regex and its `toString`.